### PR TITLE
Util/vector_emplace_back.hpp: Utility function to wrap around missing operations in `std::vector<bool>`.

### DIFF
--- a/Ev/map.hpp
+++ b/Ev/map.hpp
@@ -5,6 +5,7 @@
 #include"Ev/concurrent.hpp"
 #include"Ev/yield.hpp"
 #include"Util/make_unique.hpp"
+#include"Util/vector_emplace_back.hpp"
 #include<algorithm>
 #include<iterator>
 #include<memory>
@@ -158,7 +159,11 @@ private:
 				fail = nullptr;
 				auto rv = std::vector<b>();
 				for (auto& r : results) {
-					rv.emplace_back(std::move(*r));
+					Util::vector_emplace_back( rv
+								 , std::move(
+									*r
+								   )
+								 );
 				}
 				return pass(std::move(rv));
 			}

--- a/Makefile.am
+++ b/Makefile.am
@@ -404,6 +404,7 @@ libclboss_la_SOURCES = \
 	Util/Str.hpp \
 	Util/make_unique.hpp \
 	Util/stringify.hpp \
+	Util/vector_emplace_back.hpp \
 	Uuid.cpp \
 	Uuid.hpp
 

--- a/Stats/ReservoirSampler.hpp
+++ b/Stats/ReservoirSampler.hpp
@@ -1,6 +1,7 @@
 #ifndef STATS_RESERVOIRSAMPLER_HPP
 #define STATS_RESERVOIRSAMPLER_HPP
 
+#include"Util/vector_emplace_back.hpp"
 #include<cstdint>
 #include<random>
 #include<vector>
@@ -50,7 +51,9 @@ public:
 			wsum += w;
 
 		if (selected.size() < max_selected) {
-			selected.emplace_back(std::move(s));
+			Util::vector_emplace_back( selected
+						 , std::move(s)
+						 );
 			return;
 		}
 

--- a/Util/vector_emplace_back.hpp
+++ b/Util/vector_emplace_back.hpp
@@ -1,0 +1,61 @@
+#ifndef UTIL_VECTOR_EMPLACE_BACK_HPP
+#define UTIL_VECTOR_EMPLACE_BACK_HPP
+
+#include<utility>
+#include<vector>
+
+namespace Util {
+
+namespace VectorEmplaceBackPrivate {
+
+template<typename T>
+struct Emplacer {
+	::std::vector<T>& vec;
+
+	Emplacer(::std::vector<T>& vec_) : vec(vec_) { }
+
+	template<typename... As>
+	void emplace_back(As&&... as) {
+		vec.emplace_back(::std::forward<As>(as)...);
+	}
+};
+template<>
+struct Emplacer<bool> {
+	::std::vector<bool>& vec;
+
+	Emplacer(::std::vector<bool>& vec_) : vec(vec_) { }
+
+	template<typename... As>
+	void emplace_back(As&&... as) {
+		vec.push_back(bool(::std::forward<As>(as)...));
+	}
+};
+
+}
+
+/** Util::vector_emplace_back
+ *
+ * @desc Templated function to emplace an object into a vector of
+ * specific types.
+ *
+ * C++11 defines `std::vector<bool>` specially, indicating that the
+ * it may use a "packed" form where 8 `bool` objects are stored in the
+ * same space as a `char`.
+ *
+ * However, in C++11 some operations on `std::vector<T>` are **not**
+ * present in `std::vector<bool>`, precisely because of the possibility
+ * of using a "packed" form for `std::vector<bool>` objects.
+ * `emplace_back` is one of those functions.
+ *
+ * This limitation is lifted in C++14, however some compilers may be
+ * strict in imposing this limitation for `std::vector<bool>`.
+ */
+template<typename T, typename... As>
+void vector_emplace_back(std::vector<T>& vec, As&&... as) {
+	auto emplacer = VectorEmplaceBackPrivate::Emplacer<T>(vec);
+	emplacer.emplace_back(::std::forward<As>(as)...);
+}
+
+}
+
+#endif /* !defined(UTIL_VECTOR_EMPLACE_BACK_HPP) */

--- a/tests/ev/test_map.cpp
+++ b/tests/ev/test_map.cpp
@@ -25,6 +25,11 @@ int main() {
 		flag = true;
 		return Ev::lift(i);
 	};
+	auto is_odd = [](int i) {
+		if (i % 2)
+			return Ev::lift(true);
+		return Ev::lift(false);
+	};
 
 	auto code = Ev::lift().then([&]() {
 
@@ -65,6 +70,20 @@ int main() {
 		assert(ovec.size() == 0);
 		/* Nothing to process, so it should not have been called.  */
 		assert(!flag);
+
+		/* Check vector of boolean.  */
+		auto vec = std::vector<int>();
+		vec.push_back(0);
+		vec.push_back(1);
+		vec.push_back(43);
+		vec.push_back(42);
+		return Ev::map(is_odd, std::move(vec));
+	}).then([&](std::vector<bool> ovec) {
+		assert(ovec.size() == 4);
+		assert(ovec[0] == false);
+		assert(ovec[1] == true);
+		assert(ovec[2] == true);
+		assert(ovec[3] == false);
 
 		return Ev::lift(0);
 	});


### PR DESCRIPTION
Fixes: #14 

@hosiawak can you check?