### PR TITLE
Stats/WeightedMedian.hpp: Add missing include for `std::plus` template.

### DIFF
--- a/Stats/WeightedMedian.hpp
+++ b/Stats/WeightedMedian.hpp
@@ -2,6 +2,7 @@
 #define STATS_WEIGHTEDMEDIAN_HPP
 
 #include<algorithm>
+#include<functional>
 #include<stdexcept>
 #include<utility>
 #include<vector>


### PR DESCRIPTION
Fixes: #19 

@hosiawak please check, here is tarball with pregenerated `configure`: 
[clboss-missing-include-functional.tar.gz](https://github.com/ZmnSCPxj/clboss/files/5500503/clboss-missing-include-functional.tar.gz)
