### PR TITLE
More FreeBSD fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -430,7 +430,7 @@ EXTRA_DIST = \
 	external/jsmn/LICENSE \
 	external/jsmn/jsmn.h
 
-AM_CXXFLAGS = -Wall -Werror $(PTHREAD_CFLAGS) $(libev_CFLAGS) $(SQLITE3_CFLAGS) $(CURL_CFLAGS)
+AM_CXXFLAGS = -Wall -Werror $(PTHREAD_CFLAGS) $(libev_CFLAGS) $(SQLITE3_CFLAGS) $(CURL_CFLAGS) $(CLBOSS_CXXFLAGS)
 LDADD = libclboss.la $(PTHREAD_LIBS) $(libev_LIBS) $(SQLITE3_LIBS) $(CURL_LIBS)
 
 ACLOCAL_AMFLAGS = -I m4

--- a/Net/ProxyConnector.cpp
+++ b/Net/ProxyConnector.cpp
@@ -1,5 +1,6 @@
 #include<errno.h>
 #include<netdb.h>
+#include<netinet/in.h>
 #include<string.h>
 #include<sys/socket.h>
 #include<sys/types.h>

--- a/Net/SocketFd.cpp
+++ b/Net/SocketFd.cpp
@@ -1,5 +1,6 @@
 #include<errno.h>
 #include<stdexcept>
+#include<string>
 #include<string.h>
 #include<sys/socket.h>
 #include<unistd.h>

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,22 @@ AX_LIB_CURL(,[:],[
 # Checks for header files.
 
 # Checks for typedefs, structures, and compiler characteristics.
+CLBOSS_CXXFLAGS=''
+AC_SUBST([CLBOSS_CXXFLAGS])
+# Determine if compiling ev.h succeeds with -Wno-noexcept-type
+# On FreeBSD ev.h compilation fails without this flag.
+AC_MSG_CHECKING([if compiler compiles ev.h with -Wno-noexcept-type])
+saved_CXXFLAGS="${CXXFLAGS}"
+CXXFLAGS="${CXXFLAGS} ${libev_CFLAGS} -Wno-noexcept-type"
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#include<ev.h>
+]])], [ # then
+    CLBOSS_CXXFLAGS="${CLBOSS_CXXFLAGS} -Wno-noexcept-type"
+    AC_MSG_RESULT([yes])
+], [ # else
+    AC_MSG_RESULT([no])
+])
+CXXFLAGS="${saved_CXXFLAGS}"
 
 # Checks for library functions.
 


### PR DESCRIPTION
@hosiawak please check: 
[clboss-more-freebsd.tar.gz](https://github.com/ZmnSCPxj/clboss/files/5505187/clboss-more-freebsd.tar.gz)

This should no longer require an explicit `CXXFLAGS="-Wno-noexcept-type"`, it "should" suppress the warning on FreeBSD even with a plain `./configure`.
