### PR TITLE
Boss/Mod/Rpc.cpp: Throw exception when eof encountered in read end of socket.

### DIFF
--- a/Boss/Mod/Rpc.cpp
+++ b/Boss/Mod/Rpc.cpp
@@ -191,6 +191,12 @@ private:
 					std::string("Rpc: read: ") +
 					strerror(errno)
 				);
+			if (res == 0)
+				/* Unexpected end of file!  */
+				throw std::runtime_error(
+					"Rpc: read: unexpected end-of-file "
+					"in RPC socket."
+				);
 			if (std::size_t(res) < chunk_size)
 				read_buffer.resize(offset + res);
 		}


### PR DESCRIPTION
Fixes #26

Hopefully.  @hosiawak please check: [clboss-die-from-rpc.tar.gz](https://github.com/ZmnSCPxj/clboss/files/5518298/clboss-die-from-rpc.tar.gz)