### PR TITLE
Net/ProxyConnector.cpp: Retry up to 100 times if the proxy reports general SOCKS5 failure.

### DIFF
--- a/Net/ProxyConnector.hpp
+++ b/Net/ProxyConnector.hpp
@@ -13,6 +13,11 @@ private:
 	std::string proxy_host;
 	int proxy_port;
 
+	Net::SocketFd
+	single_connect( std::string const& host, int port
+		      , bool& socks5_general_error
+		      );
+
 public:
 	ProxyConnector() =delete;
 	explicit ProxyConnector( std::unique_ptr<Net::Connector> base_


### PR DESCRIPTION
Good morning @hosiawak, I tried this workaround where we try up to 100 times to `CONNECT` if the proxy sends back a general failure, could you please check on the system where `proxy`+`always-use-proxy` leads to CLBOSS thinking we are offline?

After compiling but before restarting your node, please try this command a dozen times:

    ./dev-proxy-connect 127.0.0.1 9050 www.google.com 443

If that consistently says "Not connected" then do not bother restarting your node and just tell me.  However if it consistently says "Connected" could you please try restarting your node with this version of CLBOSS and with `proxy` + `always-use-proxy=true`?

[clboss-proxy-100.tar.gz](https://github.com/ZmnSCPxj/clboss/files/5541748/clboss-proxy-100.tar.gz)

