### PR TITLE
DnsSeed/get.cpp: Use `dig -v` to check for `dig` install.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- Use `dig -v` to check for `dig` install, instead of `dig localhost`, as the latter may trigger a "real" lookup that will inevitably fail.
+
 0.10 Made of Explodium
 0.9A
 - Avoid `DELETE ... ORDER BY`, which might not be enabled on the SQLITE3 available on some systems.

--- a/DnsSeed/get.cpp
+++ b/DnsSeed/get.cpp
@@ -23,7 +23,7 @@ std::string enstring(a const& val) {
 namespace DnsSeed {
 
 Ev::Io<std::string> can_get() {
-	return Ev::runcmd("dig", {"localhost"}).then([](std::string _) {
+	return Ev::runcmd("dig", {"-v"}).then([](std::string _) {
 		return Ev::lift(std::string(""));
 	}).catching<std::runtime_error>([](std::runtime_error const& _) {
 		return Ev::lift(std::string(


### PR DESCRIPTION
Fixes #49

@erikarvstedt can you check if this works?

Note that while it speeds up the pre-manifest times, due to `always-use-proxy` it will do a later check if `torify dig` works on each DNS seed (but as a background task after initialization).  This will again take 18 seconds or so with the WAN down.  If you are testing only "does it work" and you try to cleanly shut down `lightningd` (as opposed to `kill -s SIGINT`) immediately afterwards, the delay will still persist, this time on shutdown (because we have no facility that keeps track of forked processes and kills them when we want to die ourselves).

If so, maybe implementing a new `--clboss-disable-dnsseed` flag might do better, then you can add that in the config of your testcase.