### PR TITLE
Boss/Mod/InternetConnectionMonitor.cpp: Fix compile on MacOS.

### DIFF
--- a/Boss/Mod/InternetConnectionMonitor.cpp
+++ b/Boss/Mod/InternetConnectionMonitor.cpp
@@ -187,7 +187,7 @@ private:
 			/* If one of the servers passed, it turns out we
 			 * are connected after all.  */
 			auto res = false;
-			for (auto const& r : results) {
+			for (auto r : results) {
 				if (r) {
 					res = true;
 					bitvector += "1";


### PR DESCRIPTION
Hi @hosiawak, this fixes the compile problem you reported in https://github.com/ZmnSCPxj/clboss/pull/52#issuecomment-752442146

Could you please try to check compile on FreeBSD and MacOS? [clboss-for-vector-bool.tar.gz](https://github.com/ZmnSCPxj/clboss/files/5754355/clboss-for-vector-bool.tar.gz)
