### PR TITLE
Boss/Mod/FundsMover/Attempter.cpp: Be less willing to pay extra for randomized routes.

### DIFF
--- a/Boss/Mod/FundsMover/Attempter.cpp
+++ b/Boss/Mod/FundsMover/Attempter.cpp
@@ -18,6 +18,13 @@
 #include<string>
 #include<vector>
 
+namespace {
+
+auto initial_fuzzpercent = double(11.0);
+auto step_fuzzpercent = double(11.0);
+
+}
+
 namespace Boss { namespace Mod { namespace FundsMover {
 
 class Attempter::Impl : public std::enable_shared_from_this<Impl> {
@@ -108,7 +115,7 @@ private:
 						))
 				    + Ln::Amount::msat(1)
 				    ;
-			fuzzpercent = 99.0;
+			fuzzpercent = initial_fuzzpercent;
 
 			return getroute();
 		});
@@ -510,7 +517,7 @@ private:
 
 	Ev::Io<void> fee_failed() {
 		if (fuzzpercent > 0) {
-			fuzzpercent -= 22;
+			fuzzpercent -= step_fuzzpercent;
 			if (fuzzpercent < 0)
 				fuzzpercent = 0;
 			return getroute();

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- Make `FundsMover` much less willing to pay extra for more private randomized routes.
 - New `EarningsRebalancer` is now the primary rebalancer to replace the role of `InitialRebalancer` in previous releases; it will base its rebalancing decisions on earnings of each channel.
 - `InitialRebalancer` will now limit how much it will spend on rebalances, as it is intended for the *initial* rebalancing of new channels.
 - `FundsMover` is now more parsimonious about its fee budget when it splits moved funding attempts.


### PR DESCRIPTION
Put as a PR so somebody else (@hosiawak?) can double-check my thinking.

`lightningd` actually has route randomization implemented in `getroute`, however its current `pay` implementation does not actually use it.  Route randomization gives privacy benefits, as (1) surveillors can trick naive `pay` implementations to going through their surveillance node by just advertising for tiny feerates (trading off fees for more information) and (2) always using the shortest route makes it trivial for surveillors to bound the possible destination of a payment to a small set of nodes.  Increased randomization also tends to mean we try out a wider variety of possible routes instead of retrying the same few ones.

Currently `FundsMover` uses rather high fuzzing of 99%.  This roughly translate to be willing to pay up to about double the fee compared to the cheapest route..

On the other hand, one can argue that a rebalance aka a self-payment "conveys no information", as you are paying yourself and therefore it does not link you to your actual economic partners.  It could theoretically leak an aggregate of other payments that went through your node, as rebalances are basically triggered due to forwards you facilitated unbalancing your channels, but aggregate information like that leaks very little information anyway.  So maybe lowering the route randomization parameter might be better; route randomization is needed for payments to other nodes, but maybe not so much for self-payments.