### PR TITLE
Boss/Mod/FeeModderByExpenditures.cpp: Add module to try to increase earnings for high-expenditure channels.

### DIFF
--- a/Boss/Mod/FeeModderByExpenditures.cpp
+++ b/Boss/Mod/FeeModderByExpenditures.cpp
@@ -1,0 +1,131 @@
+#include"Boss/Mod/FeeModderByExpenditures.hpp"
+#include"Boss/ModG/ReqResp.hpp"
+#include"Boss/Msg/ProvideChannelFeeModifier.hpp"
+#include"Boss/Msg/RequestEarningsInfo.hpp"
+#include"Boss/Msg/ResponseEarningsInfo.hpp"
+#include"Boss/Msg/SolicitChannelFeeModifier.hpp"
+#include"Boss/log.hpp"
+#include"Ev/Io.hpp"
+#include"S/Bus.hpp"
+#include"Util/make_unique.hpp"
+#include"Util/stringify.hpp"
+#include<math.h>
+#include<string>
+
+namespace {
+
+/* Base to use for logarithm.  */
+auto constexpr log_base = double(10);
+/* Maximum multiplier.  */
+auto constexpr max_multiplier = double(5.0);
+
+}
+
+namespace Boss { namespace Mod {
+
+class FeeModderByExpenditures::Impl {
+private:
+	S::Bus& bus;
+	Boss::ModG::ReqResp< Msg::RequestEarningsInfo
+			   , Msg::ResponseEarningsInfo
+			   > earnings_rr;
+
+	void start() {
+		bus.subscribe< Msg::SolicitChannelFeeModifier
+			     >([this](Msg::SolicitChannelFeeModifier const& _) {
+			return bus.raise(Msg::ProvideChannelFeeModifier{
+				[this](Ln::NodeId n, std::uint32_t _, std::uint32_t __) {
+					return modify_fee(n);
+				}
+			});
+		});
+	}
+
+	Ev::Io<double>
+	modify_fee(Ln::NodeId const& n) {
+		return Ev::lift().then([this, n]() {
+			return earnings_rr.execute(Msg::RequestEarningsInfo{
+				nullptr, n
+			});
+		}).then([this, n](Msg::ResponseEarningsInfo e) {
+			auto msg = std::string();
+			auto factor = double();
+			decide_fee_factor(msg, factor, e.out_earnings, e.out_expenditures);
+
+			return Boss::log( bus, Debug
+					, "FeeModderByExpenditures: %s "
+					  "(earn = %s, spend = %s): %s"
+					, Util::stringify(n).c_str()
+					, Util::stringify(e.out_earnings).c_str()
+					, Util::stringify(e.out_expenditures).c_str()
+					, msg.c_str()
+					).then([factor]() {
+				return Ev::lift(factor);
+			});
+		});
+	}
+
+	void decide_fee_factor( std::string& msg
+			      , double& factor
+			      , Ln::Amount earnings
+			      , Ln::Amount expenditures
+			      ) {
+		if (earnings >= expenditures) {
+			msg = "Channel not at a loss, factor = 1.";
+			factor = 1.0;
+			return;
+		}
+
+		/* Avoid divide by 0.  */
+		if (earnings == Ln::Amount::msat(0)) {
+			msg = std::string("No earnings, factor = max = ")
+			    + Util::stringify(int(max_multiplier))
+			    + "."
+			    ;
+			factor = max_multiplier;
+			return;
+		}
+
+		auto ratio = expenditures / earnings;
+		factor = 1.0 + round(::log(ratio) / ::log(log_base));
+		msg = std::string("spend / earn = ")
+		    + Util::stringify(ratio)
+		    + ", factor = "
+		    ;
+		if (factor <= max_multiplier)
+			msg += Util::stringify(int(factor))
+			     + "."
+			     ;
+		else {
+			factor = max_multiplier;
+			msg += std::string("max = ")
+			     + Util::stringify(int(factor))
+			     + "."
+			     ;
+		}
+	}
+
+public:
+	Impl() =delete;
+	Impl(Impl&&) =delete;
+	explicit
+	Impl( S::Bus& bus_
+	    ) : bus(bus_)
+	      , earnings_rr( bus_
+			   , [](Msg::RequestEarningsInfo& m, void* p) {
+				m.requester = p;
+			     }
+			   , [](Msg::ResponseEarningsInfo& m) {
+				return m.requester;
+			     }
+			   )
+	      { start(); }
+};
+
+FeeModderByExpenditures::FeeModderByExpenditures(FeeModderByExpenditures&&) =default;
+FeeModderByExpenditures::~FeeModderByExpenditures() =default;
+
+FeeModderByExpenditures::FeeModderByExpenditures(S::Bus& bus)
+	: pimpl(Util::make_unique<Impl>(bus)) { }
+
+}}

--- a/Boss/Mod/FeeModderByExpenditures.hpp
+++ b/Boss/Mod/FeeModderByExpenditures.hpp
@@ -1,0 +1,33 @@
+#ifndef BOSS_MOD_FEEMODDERBYEXPENDITURES_HPP
+#define BOSS_MOD_FEEMODDERBYEXPENDITURES_HPP
+
+#include<memory>
+
+namespace S { class Bus; }
+
+namespace Boss { namespace Mod {
+
+/** class Boss::Mod::FeeModderByExpenditures
+ *
+ * @brief Modify fees according to expenditures.
+ * If we have lots of expenditures, increase the fee
+ * we ask for.
+ */
+class FeeModderByExpenditures {
+private:
+	class Impl;
+	std::unique_ptr<Impl> pimpl;
+
+public:
+	FeeModderByExpenditures() =delete;
+
+	FeeModderByExpenditures(FeeModderByExpenditures&&);
+	~FeeModderByExpenditures();
+
+	explicit
+	FeeModderByExpenditures(S::Bus&);
+};
+
+}}
+
+#endif /* !defined(BOSS_MOD_FEEMODDERBYEXPENDITURES_HPP) */

--- a/Boss/Mod/all.cpp
+++ b/Boss/Mod/all.cpp
@@ -23,6 +23,7 @@
 #include"Boss/Mod/EarningsRebalancer.hpp"
 #include"Boss/Mod/EarningsTracker.hpp"
 #include"Boss/Mod/FeeModderByBalance.hpp"
+#include"Boss/Mod/FeeModderByExpenditures.hpp"
 #include"Boss/Mod/FeeModderBySize.hpp"
 #include"Boss/Mod/ForwardFeeMonitor.hpp"
 #include"Boss/Mod/FundsMover/Main.hpp"
@@ -158,6 +159,7 @@ std::shared_ptr<void> all( std::ostream& cout
 	all->install<ChannelFeeManager>(bus);
 	all->install<FeeModderBySize>(bus);
 	all->install<FeeModderByBalance>(bus);
+	all->install<FeeModderByExpenditures>(bus);
 
 	/* HTLC manipulation.  */
 	all->install<HtlcAcceptor>(bus, *waiter);

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- New `FeeModderByExpenditures` will now boost fees for channels with losses.
 - Make `FundsMover` much less willing to pay extra for more private randomized routes.
 - New `EarningsRebalancer` is now the primary rebalancer to replace the role of `InitialRebalancer` in previous releases; it will base its rebalancing decisions on earnings of each channel.
 - `InitialRebalancer` will now limit how much it will spend on rebalances, as it is intended for the *initial* rebalancing of new channels.

--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,8 @@ libclboss_la_SOURCES = \
 	Boss/Mod/EarningsTracker.hpp \
 	Boss/Mod/FeeModderByBalance.cpp \
 	Boss/Mod/FeeModderByBalance.hpp \
+	Boss/Mod/FeeModderByExpenditures.cpp \
+	Boss/Mod/FeeModderByExpenditures.hpp \
 	Boss/Mod/FeeModderBySize.cpp \
 	Boss/Mod/FeeModderBySize.hpp \
 	Boss/Mod/ForwardFeeMonitor.cpp \


### PR DESCRIPTION
Closes: #56

I have mixed feelings about this.  On my system, all channels will be hit by this, and while it *looks* like it increases the fee earnings, it might be better to actually tweak `FeeModderBySize` instead; in principle, we don't have to signal how much we have lost in rebalances.  In short, I think doing an across-the-board increase in fees we charge would be better than basing on our own local expenditures --- in all likelihood we need to bump up `FeeModderBySize` instead.

Lemme make an alternate patch and provide some packages, that will take several hours.