### PR TITLE
Tweak channel fees to make base higher and proportional lower

### DIFF
--- a/Boss/Mod/ChannelFeeManager.hpp
+++ b/Boss/Mod/ChannelFeeManager.hpp
@@ -3,6 +3,7 @@
 
 #include<cstdint>
 #include<functional>
+#include<utility>
 #include<vector>
 
 namespace Ev { template<typename a> class Io; }
@@ -24,10 +25,12 @@ private:
 
 	bool initted;
 	bool soliciting;
-	std::vector<std::function< Ev::Io<double>( Ln::NodeId
-						 , std::uint32_t // b
-						 , std::uint32_t // p
-						 )
+	std::vector<std::function< Ev::Io<std::pair< double // bm
+						   , double // pm
+						   >>( Ln::NodeId
+						     , std::uint32_t // b
+						     , std::uint32_t // p
+						     )
 				 >> modifiers;
 
 	void start();

--- a/Boss/Mod/FeeModderByForwarder.cpp
+++ b/Boss/Mod/FeeModderByForwarder.cpp
@@ -1,0 +1,45 @@
+#include"Boss/Mod/FeeModderByForwarder.hpp"
+#include"Boss/Msg/ProvideChannelFeeModifierDetailed.hpp"
+#include"Boss/Msg/SolicitChannelFeeModifier.hpp"
+#include"Ev/Io.hpp"
+#include"Ln/NodeId.hpp"
+#include"S/Bus.hpp"
+#include"Util/make_unique.hpp"
+
+namespace {
+
+/* Increase our base fee, reduce our prop fee.  */
+auto constexpr base_mult = double(2.0);
+auto constexpr prop_mult = double(0.5);
+
+}
+
+namespace Boss { namespace Mod {
+
+class FeeModderByForwarder::Impl {
+public:
+	Impl()=delete;
+	Impl(Impl&&) =delete;
+	Impl(Impl const&) =delete;
+	explicit
+	Impl(S::Bus& bus) {
+		bus.subscribe< Msg::SolicitChannelFeeModifier
+			     >([&bus](Msg::SolicitChannelFeeModifier const& _) {
+			return bus.raise(Msg::ProvideChannelFeeModifierDetailed{
+				[](Ln::NodeId, std::uint32_t, std::uint32_t) {
+					return Ev::lift(std::make_pair(
+						base_mult, prop_mult
+					));
+				}
+			});
+		});
+	}
+};
+
+
+FeeModderByForwarder::FeeModderByForwarder(FeeModderByForwarder&&) =default;
+FeeModderByForwarder::~FeeModderByForwarder() =default;
+FeeModderByForwarder::FeeModderByForwarder(S::Bus& bus)
+	: pimpl(Util::make_unique<Impl>(bus)) { }
+
+}}

--- a/Boss/Mod/FeeModderByForwarder.hpp
+++ b/Boss/Mod/FeeModderByForwarder.hpp
@@ -1,0 +1,50 @@
+#ifndef BOSS_MOD_FEEMODDERBYFORWARDER_HPP
+#define BOSS_MOD_FEEMODDERBYFORWARDER_HPP
+
+#include<memory>
+
+namespace S { class Bus; }
+
+namespace Boss { namespace Mod {
+
+/** class Boss::Mod::FeeModderByForwarder
+ *
+ * @brief Modifies channel fees simply because we are a
+ * forwarding node.
+ *
+ * @desc The logic here is that a forwarder is really in
+ * the business of aggregating multiple small payments.
+ * This is because the actual payments made by payers is
+ * determined by the actual transaction (payment for a
+ * product or service).
+ *
+ * However, as a forwarding node, we (presumably!) have a
+ * good amount of capacity in our channels, and can service
+ * many payments through them.
+ * So our strategy is to charge the many payments going
+ * through us by boosting our base fee and lowering our
+ * proportional fee.
+ * This allows us to afford to perform rebalances.
+ *
+ * In effect, the many payments going through our node are
+ * aggregated into a smaller number of rebalances which
+ * effectively take more expensive paths.
+ */
+class FeeModderByForwarder {
+private:
+	class Impl;
+	std::unique_ptr<Impl> pimpl;
+
+public:
+	FeeModderByForwarder() =delete;
+
+	FeeModderByForwarder(FeeModderByForwarder&&);
+	~FeeModderByForwarder();
+
+	explicit
+	FeeModderByForwarder(S::Bus& bus);
+};
+
+}}
+
+#endif /* !defined(BOSS_MOD_FEEMODDERBYFORWARDER_HPP) */

--- a/Boss/Mod/all.cpp
+++ b/Boss/Mod/all.cpp
@@ -23,6 +23,7 @@
 #include"Boss/Mod/EarningsRebalancer.hpp"
 #include"Boss/Mod/EarningsTracker.hpp"
 #include"Boss/Mod/FeeModderByBalance.hpp"
+#include"Boss/Mod/FeeModderByForwarder.hpp"
 #include"Boss/Mod/FeeModderBySize.hpp"
 #include"Boss/Mod/ForwardFeeMonitor.hpp"
 #include"Boss/Mod/FundsMover/Main.hpp"
@@ -158,6 +159,7 @@ std::shared_ptr<void> all( std::ostream& cout
 	all->install<ChannelFeeManager>(bus);
 	all->install<FeeModderBySize>(bus);
 	all->install<FeeModderByBalance>(bus);
+	all->install<FeeModderByForwarder>(bus);
 
 	/* HTLC manipulation.  */
 	all->install<HtlcAcceptor>(bus, *waiter);

--- a/Boss/Msg/ProvideChannelFeeModifierDetailed.hpp
+++ b/Boss/Msg/ProvideChannelFeeModifierDetailed.hpp
@@ -1,0 +1,37 @@
+#ifndef BOSS_MSG_PROVIDECHANNELFEEMODIFIERDETAILED_HPP
+#define BOSS_MSG_PROVIDECHANNELFEEMODIFIERDETAILED_HPP
+
+#include<functional>
+#include<utility>
+
+namespace Ev { template<typename a> class Io; }
+namespace Ln { class NodeId; }
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::ProvideChannelFeeModifierDetailed
+ *
+ * @brief emitted in response to the `Boss::Msg::SolicitChannelFeeModifier`
+ * message.
+ *
+ * @desc the function you put into this message is given the node ID,
+ * plus the raw base median feerate and the raw proportional median
+ * feerate.
+ *
+ * The given function must then return a pair of `double`s, the `.first`
+ * of which is multiplied to the `base` median fee, the `.second` of
+ * which is multiplied to the `proportional` median fee.
+ */
+struct ProvideChannelFeeModifierDetailed {
+	std::function< Ev::Io<std::pair< double /* base_multiplier */
+				       , double /* proportional_multiplier */
+				       >>( Ln::NodeId
+					 , std::uint32_t /* base */
+					 , std::uint32_t /* proportional */
+					 )
+		     > modifier;
+};
+
+}}
+
+#endif /* !defined(BOSS_MSG_PROVIDECHANNELFEEMODIFIERDETAILED_HPP) */

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- New `FeeModderByForwarder` to adjust our channel fees better for being a forwarding node.
+
 0.11A
 - Make `FundsMover` much less willing to pay extra for more private randomized routes.
 - New `EarningsRebalancer` is now the primary rebalancer to replace the role of `InitialRebalancer` in previous releases; it will base its rebalancing decisions on earnings of each channel.

--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,8 @@ libclboss_la_SOURCES = \
 	Boss/Mod/EarningsTracker.hpp \
 	Boss/Mod/FeeModderByBalance.cpp \
 	Boss/Mod/FeeModderByBalance.hpp \
+	Boss/Mod/FeeModderByForwarder.cpp \
+	Boss/Mod/FeeModderByForwarder.hpp \
 	Boss/Mod/FeeModderBySize.cpp \
 	Boss/Mod/FeeModderBySize.hpp \
 	Boss/Mod/ForwardFeeMonitor.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -259,6 +259,7 @@ libclboss_la_SOURCES = \
 	Boss/Msg/ProposeConnectCandidates.hpp \
 	Boss/Msg/ProposePatronlessChannelCandidate.hpp \
 	Boss/Msg/ProvideChannelFeeModifier.hpp \
+	Boss/Msg/ProvideChannelFeeModifierDetailed.hpp \
 	Boss/Msg/ProvideHtlcAcceptedDeferrer.hpp \
 	Boss/Msg/ProvideStatus.hpp \
 	Boss/Msg/ProvideSwapQuotation.hpp \


### PR DESCRIPTION
This follows the "forwarder is payment aggregator" argument, which is that the forwarding node is in the business of aggregating multiple small payments via the shortest path (through their own node) and using longer paths to ensure their shortest-path channels remain balanced.  In order to earn, the forwarding node depends on the base fee and not the proportional fee. https://github.com/ZmnSCPxj/clboss/issues/56#issuecomment-761904848

* Tarball: [clboss-by-forwarder.tar.gz](https://github.com/ZmnSCPxj/clboss/files/5834416/clboss-by-forwarder.tar.gz)

This is not an alternate to #59  or #61 , I will likely merge this in regardless, but it might be useful for others to actually have a look at it and check if the logic in the "forwarder is payment aggregator" argument makes sense.