### PR TITLE
Have explicit .onion Boltz

### DIFF
--- a/Boltz/Connection.hpp
+++ b/Boltz/Connection.hpp
@@ -1,59 +1,27 @@
 #ifndef BOLTZ_CONNECTION_HPP
 #define BOLTZ_CONNECTION_HPP
 
-#include<memory>
-#include<stdexcept>
-#include<string>
-
-namespace Ev { template<typename a> class Io; }
-namespace Ev { class ThreadPool; }
-namespace Jsmn { class Object; }
-namespace Json { class Out; }
+#include"Boltz/Detail/NormalConnection.hpp"
 
 namespace Boltz {
 
 /** class Boltz::Connection
  *
- * @brief handles a connection to some Boltz
- * server, and wrangles JSON comunications
- * with it.
+ * @brief shim for `Boltz::Detail::NormalConnection`.
  */
-class Connection {
-private:
-	class Impl;
-	std::unique_ptr<Impl> pimpl;
-
+class Connection : public Boltz::Detail::NormalConnection {
 public:
-	Connection() =delete;
-	Connection(Connection const&) =delete;
-
-	Connection(Connection&&);
-	~Connection();
 	explicit
 	Connection( Ev::ThreadPool& threadpool
 		  /* Base address of the API endpoint.  */
 		  , std::string api_base = "https://boltz.exchange/api"
 		  /* SOCKS5 proxy to use.  Empty string means no proxy.  */
 		  , std::string proxy = ""
-		  );
-
-	/* Send an API request.  */
-	Ev::Io<Jsmn::Object>
-	api( std::string api /* e.g. "/createswap" */
-	   /* nullptr if GET, or the request body if POST.  */
-	   , std::unique_ptr<Json::Out> params
-	   );
-};
-
-/** Boltz::ApiError
- *
- * @brief thrown when communications with
- * the BOLTZ server has problems.
- */
-class ApiError : public std::runtime_error {
-public:
-	ApiError(std::string const& e
-		) : std::runtime_error(e) { }
+		  ) : Detail::NormalConnection( threadpool
+					      , std::move(api_base)
+					      , std::move(proxy)
+					      )
+		    { }
 };
 
 }

--- a/Boltz/ConnectionIF.hpp
+++ b/Boltz/ConnectionIF.hpp
@@ -1,0 +1,46 @@
+#ifndef BOLTZ_CONNECTIONIF_HPP
+#define BOLTZ_CONNECTIONIF_HPP
+
+#include<memory>
+#include<stdexcept>
+#include<string>
+
+namespace Ev { template<typename a> class Io; }
+namespace Jsmn { class Object; }
+namespace Json { class Out; }
+
+namespace Boltz {
+
+/** class Boltz::ConnectionIF
+ *
+ * @brief interface to an object that provides
+ * access to a Boltz API.
+ */
+class ConnectionIF {
+public:
+	virtual ~ConnectionIF() { }
+
+	/* Send an API request.  */
+	virtual
+	Ev::Io<Jsmn::Object>
+	api( std::string api /* e.g. "/createswap" */
+	   /* nullptr if GET, or the request body if POST.  */
+	   , std::unique_ptr<Json::Out> params
+	   ) =0;
+};
+
+
+/** Boltz::ApiError
+ *
+ * @brief thrown when communications with
+ * the BOLTZ server has problems.
+ */
+class ApiError : public std::runtime_error {
+public:
+	ApiError(std::string const& e
+		) : std::runtime_error(e) { }
+};
+
+}
+
+#endif /* !defined(BOLTZ_CONNECTIONIF_HPP) */

--- a/Boltz/Detail/FallbackConnection.cpp
+++ b/Boltz/Detail/FallbackConnection.cpp
@@ -1,0 +1,36 @@
+#include"Boltz/Detail/FallbackConnection.hpp"
+#include"Ev/Io.hpp"
+#include"Json/Out.hpp"
+#include"Util/make_unique.hpp"
+#include<assert.h>
+
+namespace {
+
+std::unique_ptr<Json::Out>
+copy_params(std::shared_ptr<Json::Out> const& shared_params) {
+	if (!shared_params)
+		return nullptr;
+
+	return Util::make_unique<Json::Out>(*shared_params);
+}
+
+}
+
+namespace Boltz { namespace Detail {
+
+Ev::Io<Jsmn::Object>
+FallbackConnection::api( std::string api /* e.g. "/createswap" */
+		       /* nullptr if GET, or the request body if POST.  */
+		       , std::unique_ptr<Json::Out> params
+		       ) {
+	assert(first && second);
+
+	auto save_params = std::shared_ptr<Json::Out>(std::move(params));
+	return Ev::lift().then([api, save_params, this]() {
+		return first->api(api, copy_params(save_params));
+	}).catching<Boltz::ApiError>([api, save_params, this](Boltz::ApiError e) {
+		return second->api(api, copy_params(save_params));
+	});
+}
+
+}}

--- a/Boltz/Detail/FallbackConnection.hpp
+++ b/Boltz/Detail/FallbackConnection.hpp
@@ -1,0 +1,42 @@
+#ifndef BOLTZ_DETAIL_FALLBACKCONNECTION_HPP
+#define BOLTZ_DETAIL_FALLBACKCONNECTION_HPP
+
+#include"Boltz/ConnectionIF.hpp"
+#include<memory>
+#include<utility>
+
+namespace Boltz { namespace Detail {
+
+/** class Boltz::Detail::FallbackConnection
+ *
+ * @brief a connection that tries one sub-connection first,
+ * then the other sub-connection if the first fails.
+ */
+class FallbackConnection : public Boltz::ConnectionIF {
+private:
+	std::unique_ptr<Boltz::ConnectionIF> first;
+	std::unique_ptr<Boltz::ConnectionIF> second;
+
+public:
+	FallbackConnection() =delete;
+
+	FallbackConnection(FallbackConnection&&) =default;
+
+	explicit
+	FallbackConnection( std::unique_ptr<Boltz::ConnectionIF> first_
+			  , std::unique_ptr<Boltz::ConnectionIF> second_
+			  ) : first(std::move(first_))
+			    , second(std::move(second_))
+			    { }
+
+	/* Send an API request.  */
+	Ev::Io<Jsmn::Object>
+	api( std::string api /* e.g. "/createswap" */
+	   /* nullptr if GET, or the request body if POST.  */
+	   , std::unique_ptr<Json::Out> params
+	   ) override;
+};
+
+}}
+
+#endif /* !defined(BOLTZ_DETAIL_FALLBACKCONNECTION_HPP) */

--- a/Boltz/Detail/NormalConnection.cpp
+++ b/Boltz/Detail/NormalConnection.cpp
@@ -1,4 +1,4 @@
-#include"Boltz/Connection.hpp"
+#include"Boltz/Detail/NormalConnection.hpp"
 #include"Ev/Io.hpp"
 #include"Ev/ThreadPool.hpp"
 #include"Jsmn/Object.hpp"
@@ -7,8 +7,6 @@
 #include"Util/make_unique.hpp"
 #include<assert.h>
 #include<curl/curl.h>
-
-#include<iostream>
 
 #ifdef HAVE_CONFIG_H
 # include"config.h"
@@ -123,9 +121,9 @@ private:
 
 }
 
-namespace Boltz {
+namespace Boltz { namespace Detail {
 
-class Connection::Impl {
+class NormalConnection::Impl {
 private:
 	Ev::ThreadPool& threadpool;
 	std::string api_base;
@@ -161,20 +159,20 @@ public:
 	}
 };
 
-Connection::~Connection() =default;
-Connection::Connection(Connection&&) =default;
-Connection::Connection( Ev::ThreadPool& threadpool
-		      , std::string api_base
-		      , std::string proxy
-		      ) : pimpl(Util::make_unique<Impl>( threadpool
-						       , std::move(api_base)
-						       , std::move(proxy)
-						       ))
-			{ }
+NormalConnection::~NormalConnection() =default;
+NormalConnection::NormalConnection(NormalConnection&&) =default;
+NormalConnection::NormalConnection( Ev::ThreadPool& threadpool
+				  , std::string api_base
+				  , std::string proxy
+				  ) : pimpl(Util::make_unique<Impl>( threadpool
+								   , std::move(api_base)
+								   , std::move(proxy)
+								   ))
+				    { }
 
 Ev::Io<Jsmn::Object>
-Connection::api(std::string api, std::unique_ptr<Json::Out> params) {
+NormalConnection::api(std::string api, std::unique_ptr<Json::Out> params) {
 	return pimpl->api(api, std::move(params));
 }
 
-}
+}}

--- a/Boltz/Detail/NormalConnection.hpp
+++ b/Boltz/Detail/NormalConnection.hpp
@@ -1,0 +1,46 @@
+#ifndef BOLTZ_DETAIL_NORMALCONNECTION_HPP
+#define BOLTZ_DETAIL_NORMALCONNECTION_HPP
+
+#include"Boltz/ConnectionIF.hpp"
+
+namespace Ev { class ThreadPool; }
+
+namespace Boltz { namespace Detail {
+
+/** class Boltz::Detail::NormalConnection
+ *
+ * @brief handles a connection to an actual
+ * Boltz server, and wrangles JSON comunications
+ * with it.
+ */
+class NormalConnection : public Boltz::ConnectionIF {
+private:
+	class Impl;
+	std::unique_ptr<Impl> pimpl;
+
+public:
+	NormalConnection() =delete;
+	NormalConnection(NormalConnection const&) =delete;
+
+	NormalConnection(NormalConnection&&);
+	~NormalConnection();
+	explicit
+	NormalConnection( Ev::ThreadPool& threadpool
+			/* Base address of the API endpoint.  */
+			, std::string api_base = "https://boltz.exchange/api"
+			/* SOCKS5 proxy to use.  Empty string means no proxy.  */
+			, std::string proxy = ""
+			);
+
+	/* Send an API request.  */
+	Ev::Io<Jsmn::Object>
+	api( std::string api /* e.g. "/createswap" */
+	   /* nullptr if GET, or the request body if POST.  */
+	   , std::unique_ptr<Json::Out> params
+	   ) override;
+};
+
+
+}}
+
+#endif /* !defined(BOLTZ_DETAIL_NORMALCONNECTION_HPP) */

--- a/Boltz/Detail/NullConnection.cpp
+++ b/Boltz/Detail/NullConnection.cpp
@@ -1,0 +1,16 @@
+#include"Boltz/Detail/NullConnection.hpp"
+#include"Ev/Io.hpp"
+
+namespace Boltz { namespace Detail {
+
+Ev::Io<Jsmn::Object>
+NullConnection::api( std::string api /* e.g. "/createswap" */
+		   /* nullptr if GET, or the request body if POST.  */
+		   , std::unique_ptr<Json::Out> params
+		   ) {
+	return Ev::lift().then([]() -> Ev::Io<Jsmn::Object> {
+		throw Boltz::ApiError("no connection available");
+	});
+}
+
+}}

--- a/Boltz/Detail/NullConnection.hpp
+++ b/Boltz/Detail/NullConnection.hpp
@@ -1,0 +1,24 @@
+#ifndef BOLTZ_DETAIL_NULLCONNECTION_HPP
+#define BOLTZ_DETAIL_NULLCONNECTION_HPP
+
+#include"Boltz/ConnectionIF.hpp"
+
+namespace Boltz { namespace Detail {
+
+/** class Boltz::Detail::NullConnection
+ *
+ * @brief a connection to a Boltz-like service that
+ * always fails.
+ */
+class NullConnection : public Boltz::ConnectionIF {
+public:
+	Ev::Io<Jsmn::Object>
+	api( std::string api /* e.g. "/createswap" */
+	   /* nullptr if GET, or the request body if POST.  */
+	   , std::unique_ptr<Json::Out> params
+	   ) override;
+};
+
+}}
+
+#endif /* !defined(BOLTZ_DETAIL_NULLCONNECTION_HPP) */

--- a/Boltz/Detail/ServiceImpl.hpp
+++ b/Boltz/Detail/ServiceImpl.hpp
@@ -22,8 +22,8 @@ namespace Boltz { namespace Detail {
  */
 class ServiceImpl : public Service {
 private:
-	std::string api_endpoint;
-	Boltz::Connection conn;
+	std::string label;
+	std::unique_ptr<Boltz::ConnectionIF> conn;
 	Sqlite3::Db db;
 	Secp256k1::SignerIF& signer;
 	Boltz::EnvIF& env;
@@ -34,17 +34,13 @@ public:
 	ServiceImpl(ServiceImpl&&) =delete;
 	ServiceImpl(ServiceImpl const&) =delete;
 
-	ServiceImpl( Ev::ThreadPool& threadpool_
-		   , Sqlite3::Db db_
+	ServiceImpl( Sqlite3::Db db_
 		   , Secp256k1::SignerIF& signer_
 		   , Boltz::EnvIF& env_
-		   , std::string proxy_
-		   , std::string api_endpoint_
-		   ) : api_endpoint(std::move(api_endpoint_))
-		     , conn( threadpool_
-			   , api_endpoint
-			   , std::move(proxy_)
-			   )
+		   , std::string label_
+		   , std::unique_ptr<Boltz::ConnectionIF> conn_
+		   ) : label(std::move(label_))
+		     , conn(std::move(conn_))
 		     , db(std::move(db_))
 		     , signer(signer_)
 		     , env(env_)

--- a/Boltz/Detail/SwapSetupHandler.cpp
+++ b/Boltz/Detail/SwapSetupHandler.cpp
@@ -1,5 +1,5 @@
 #include"Bitcoin/hash160.hpp"
-#include"Boltz/Connection.hpp"
+#include"Boltz/ConnectionIF.hpp"
 #include"Boltz/Detail/SwapSetupHandler.hpp"
 #include"Boltz/Detail/compute_preimage.hpp"
 #include"Boltz/Detail/match_lockscript.hpp"

--- a/Boltz/Detail/SwapSetupHandler.hpp
+++ b/Boltz/Detail/SwapSetupHandler.hpp
@@ -14,7 +14,7 @@
 #include<utility>
 #include<vector>
 
-namespace Boltz { class Connection; }
+namespace Boltz { class ConnectionIF; }
 namespace Boltz { class EnvIF; }
 namespace Boltz { struct SwapInfo; }
 namespace Ev { template<typename a> class Io; }
@@ -35,7 +35,7 @@ private:
 	Sqlite3::Db db;
 	Boltz::EnvIF& env;
 	std::string api_endpoint;
-	Boltz::Connection& conn;
+	Boltz::ConnectionIF& conn;
 	Secp256k1::Random& random;
 	std::string destinationAddress;
 	Ln::Amount offchainAmount;
@@ -45,7 +45,7 @@ private:
 			, Sqlite3::Db db_
 			, Boltz::EnvIF& env_
 			, std::string const& api_endpoint_
-			, Boltz::Connection& conn_
+			, Boltz::ConnectionIF& conn_
 			, Secp256k1::Random& random_
 			, std::string const& destinationAddress_
 			, Ln::Amount offchainAmount_
@@ -71,7 +71,7 @@ public:
 	      , Sqlite3::Db db
 	      , Boltz::EnvIF& env
 	      , std::string const& api_endpoint
-	      , Boltz::Connection& conn
+	      , Boltz::ConnectionIF& conn
 	      , Secp256k1::Random& random
 	      , std::string const& destinationAddress
 	      , Ln::Amount offchainAmount

--- a/Boltz/Detail/create_connection.cpp
+++ b/Boltz/Detail/create_connection.cpp
@@ -1,0 +1,54 @@
+#include"Boltz/Detail/FallbackConnection.hpp"
+#include"Boltz/Detail/NormalConnection.hpp"
+#include"Boltz/Detail/NullConnection.hpp"
+#include"Boltz/Detail/create_connection.hpp"
+#include"Util/make_unique.hpp"
+
+namespace Boltz { namespace Detail {
+
+std::unique_ptr<Boltz::ConnectionIF>
+create_connection( Ev::ThreadPool& threadpool
+		 /* Can be "" if no clearnet endpoint.  */
+		 , std::string clearnet_endpoint
+		 /* Can be "" if no Tor endpoint.  */
+		 , std::string tor_endpoint
+		 /* Can be "" if no Tor proxy.  */
+		 , std::string tor_proxy
+		 , bool always_use_proxy
+		 ) {
+	if (tor_proxy == "")
+		/* Pointless anyway.  */
+		tor_endpoint = "";
+
+	if (clearnet_endpoint == "") {
+		if (tor_endpoint == "")
+			return Util::make_unique<NullConnection>();
+		return Util::make_unique<NormalConnection>( threadpool
+							  , tor_endpoint
+							  , tor_proxy
+							  );
+	} else {
+		auto first = Util::make_unique<NormalConnection>( threadpool
+								, clearnet_endpoint
+								, always_use_proxy ?
+									tor_proxy : ""
+								);
+
+		auto rv = std::unique_ptr<Boltz::ConnectionIF>(std::move(first));
+
+		if (tor_endpoint != "") {
+			auto second = Util::make_unique<NormalConnection>( threadpool
+									 , tor_endpoint
+									 , tor_proxy
+									 );
+			auto combin = Util::make_unique<FallbackConnection>(
+				std::move(rv), std::move(second)
+			);
+			rv = std::move(combin);
+		}
+
+		return rv;
+	}
+}
+
+}}

--- a/Boltz/Detail/create_connection.hpp
+++ b/Boltz/Detail/create_connection.hpp
@@ -1,0 +1,30 @@
+#ifndef BOLTZ_DETAIL_CREATE_CONNECITON_HPP
+#define BOLTZ_DETAIL_CREATE_CONNECITON_HPP
+
+#include<memory>
+#include<string>
+
+namespace Boltz { class ConnectionIF; }
+namespace Ev { class ThreadPool; }
+
+namespace Boltz { namespace Detail {
+
+/** Boltz::Detail::create_connection
+ *
+ * @brief Creates a `Boltz::ConnectionIF` object appropriate
+ * for the given setup for a Boltz-like service.
+ */
+std::unique_ptr<Boltz::ConnectionIF>
+create_connection( Ev::ThreadPool& threadpool
+		 /* Can be "" if no clearnet endpoint.  */
+		 , std::string clearnet_endpoint
+		 /* Can be "" if no Tor endpoint.  */
+		 , std::string tor_endpoint
+		 /* Can be "" if no Tor proxy.  */
+		 , std::string tor_proxy
+		 , bool always_use_proxy
+		 );
+
+}}
+
+#endif /* !defined(BOLTZ_DETAIL_CREATE_CONNECITON_HPP) */

--- a/Boltz/ServiceFactory.hpp
+++ b/Boltz/ServiceFactory.hpp
@@ -3,11 +3,11 @@
 
 #include<functional>
 #include<memory>
+#include"Ev/Io.hpp"
 
 namespace Bitcoin { class Tx; }
 namespace Boltz { class EnvIF; }
 namespace Boltz { class Service; }
-namespace Ev { template<typename a> class Io; }
 namespace Ev { class ThreadPool; }
 namespace Secp256k1 { class SignerIF; }
 namespace Sqlite3 { class Db; }
@@ -47,15 +47,36 @@ public:
 		      , Boltz::EnvIF& env
 		      /* SOCKS5 proxy to use.  Empty string means no proxy.  */
 		      , std::string proxy = ""
+		      /* Whether to always use proxy even for clearnet endpoints.  */
+		      , bool always_use_proxy = false
 		      );
+
+	/** Boltz::ServiceFactory::create_service_detailed
+	 *
+	 * @brief creates a service from a particular
+	 * Boltz implementation, which can have both a
+	 * clearnet and a Tor endpoint.
+	 */
+	Ev::Io<std::unique_ptr<Service>>
+	create_service_detailed( std::string const& label
+			       , std::string const& clearnet
+			       , std::string const& onion
+			       );
 
 	/** Boltz::ServiceFactory::create_service
 	 *
 	 * @brief creates a service from a particular
 	 * API endpoint.
+	 *
+	 * @desc this interface is deprecated.
 	 */
 	Ev::Io<std::unique_ptr<Service>>
-	create_service(std::string const& api_endpoint);
+	create_service(std::string const& api_endpoint) {
+		return create_service_detailed( api_endpoint
+					      , api_endpoint
+					      , ""
+					      );
+	}
 };
 
 }

--- a/Boss/Mod/BoltzSwapper/Main.cpp
+++ b/Boss/Mod/BoltzSwapper/Main.cpp
@@ -5,13 +5,31 @@
 
 namespace {
 
-auto const boltz_instances = std::map<Boss::Msg::Network, std::vector<std::string>>
+auto const boltz_instances = std::map< Boss::Msg::Network
+				     , std::vector<Boss::Mod::BoltzSwapper::Instance>
+				     >
 { { Boss::Msg::Network_Bitcoin
-  , { "https://boltz.exchange/api"
+/* Historically, the clearnet API endpoint was used as the in-database label
+ * for Boltz services.
+ * The boltz.exchange service thus uses the API endpoint as the label for
+ * back-compatibility.
+ * Other services since then were added after we had a separate label.
+ */
+  , { { "https://boltz.exchange/api"
+      , "https://boltz.exchange/api"
+      , "http://boltzzzbnus4m7mta3cxmflnps4fp7dueu2tgurstbvrbt6xswzcocyd.onion/api"
+      }
+    , { "AutonomousOrganization@github.com"
+      , ""
+      , "http://jsyqqszgfrya6nj7nhi4hu4tdpuvfursl7dyxeiukzit5mvckqbzxpad.onion"
+      }
     }
   }
 , { Boss::Msg::Network_Testnet
-  , { "https://testnet.boltz.exchange/api"
+  , { { "https://testnet.boltz.exchange/api"
+      , "https://testnet.boltz.exchange/api"
+      , "http://tboltzzrsoc3npe6sydcrh37mtnfhnbrilqi45nao6cgc6dr7n2eo3id.onion/api"
+      }
     }
   }
 };

--- a/Boss/Mod/BoltzSwapper/ServiceCreator.hpp
+++ b/Boss/Mod/BoltzSwapper/ServiceCreator.hpp
@@ -14,6 +14,19 @@ namespace S { class Bus; }
 
 namespace Boss { namespace Mod { namespace BoltzSwapper {
 
+/** struct Boss::Mod::BoltzSwapper::Instance
+ *
+ * @brief Describes an instance of a Boltz-like exchange.
+ */
+struct Instance {
+	/* Label to use in database.  */
+	std::string label;
+	/* Clearnet API endpoint; can be "" if no clearnet.  */
+	std::string clearnet;
+	/* Tor API endpoint; can be "" if no onion.  */
+	std::string onion;
+};
+
 /** class Boss::Mod::BoltzSwapper::ServiceCreator
  *
  * @brief Constructs `ServiceModule` objects and
@@ -26,7 +39,7 @@ private:
 	Boltz::EnvIF& env;
 
 	/* Known BOLTZ instances and the networks they are for.  */
-	std::map<Boss::Msg::Network, std::vector<std::string>> const&
+	std::map<Boss::Msg::Network, std::vector<Instance>> const&
 	instances;
 
 	/* The actual services we are maintaining.  */
@@ -45,7 +58,7 @@ public:
 	ServiceCreator( S::Bus& bus_
 		      , Ev::ThreadPool& threadpool_
 		      , Boltz::EnvIF& env_
-		      , std::map<Boss::Msg::Network, std::vector<std::string>> const& instances_
+		      , std::map<Boss::Msg::Network, std::vector<Instance>> const& instances_
 		      ) : bus(bus_)
 			, threadpool(threadpool_)
 			, env(env_)

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,10 +32,12 @@ libclboss_la_SOURCES = \
 	Bitcoin/sighash.hpp \
 	Bitcoin/varint.cpp \
 	Bitcoin/varint.hpp \
-	Boltz/Connection.cpp \
 	Boltz/Connection.hpp \
+	Boltz/ConnectionIF.hpp \
 	Boltz/Detail/ClaimTxHandler.cpp \
 	Boltz/Detail/ClaimTxHandler.hpp \
+	Boltz/Detail/NormalConnection.cpp \
+	Boltz/Detail/NormalConnection.hpp \
 	Boltz/Detail/ServiceImpl.cpp \
 	Boltz/Detail/ServiceImpl.hpp \
 	Boltz/Detail/SwapSetupHandler.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,8 +36,12 @@ libclboss_la_SOURCES = \
 	Boltz/ConnectionIF.hpp \
 	Boltz/Detail/ClaimTxHandler.cpp \
 	Boltz/Detail/ClaimTxHandler.hpp \
+	Boltz/Detail/FallbackConnection.cpp \
+	Boltz/Detail/FallbackConnection.hpp \
 	Boltz/Detail/NormalConnection.cpp \
 	Boltz/Detail/NormalConnection.hpp \
+	Boltz/Detail/NullConnection.cpp \
+	Boltz/Detail/NullConnection.hpp \
 	Boltz/Detail/ServiceImpl.cpp \
 	Boltz/Detail/ServiceImpl.hpp \
 	Boltz/Detail/SwapSetupHandler.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,8 @@ libclboss_la_SOURCES = \
 	Boltz/Detail/SwapSetupHandler.hpp \
 	Boltz/Detail/compute_preimage.cpp \
 	Boltz/Detail/compute_preimage.hpp \
+	Boltz/Detail/create_connection.cpp \
+	Boltz/Detail/create_connection.hpp \
 	Boltz/Detail/find_lockup_outnum.cpp \
 	Boltz/Detail/find_lockup_outnum.hpp \
 	Boltz/Detail/initial_claim_tx.cpp \


### PR DESCRIPTION
Fixes: #45 

This adds support for fallback onion addresses in case the clearnet addresses are unavailable.

This also adds @AutonomousOrganization Boltz instance as well.

Untested!  I am running evaluation for 59/61/neither now, so unable to test this yet, bleah.