### PR TITLE
Add libtool to build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Debian packages in addition:
 * `git`
 * `automake`
 * `autoconf-archive`
+* `libtool`
 
 A design goal of CLBOSS is to reduce the above dependencies even
 further.


### PR DESCRIPTION
Without this, building fails on debian buster:

```
configure.ac:872: error: possibly undefined macro: AC_LIBTOOL_WIN32_DLL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
```