### PR TITLE
Configure min|max channel size

### DIFF
--- a/Boss/Mod/ChannelCreator/Manager.hpp
+++ b/Boss/Mod/ChannelCreator/Manager.hpp
@@ -38,6 +38,8 @@ private:
 	Boss::Mod::ChannelCandidateInvestigator::Main& investigator;
 	Boss::Mod::ChannelCreator::Carpenter& carpenter;
 	Ln::NodeId self;
+    Ln::Amount min_amount;
+    Ln::Amount max_amount;
 
 	ModG::ReqResp<Msg::RequestDowser, Msg::ResponseDowser> dowser;
 

--- a/Boss/Msg/ManifestHook.hpp
+++ b/Boss/Msg/ManifestHook.hpp
@@ -7,7 +7,7 @@ namespace Boss { namespace Msg {
 
 /** struct Boss::Msg::ManifestHook
  *
- * @brief emitted in respone to Boss::Msg::Manifestation
+ * @brief emitted in response to Boss::Msg::Manifestation
  * to register a hook.
  * Multiple modules can register the same hook and listen
  * for Boss::Msg::CommandRequest for that hook, though

--- a/Boss/Msg/ManifestNotification.hpp
+++ b/Boss/Msg/ManifestNotification.hpp
@@ -7,7 +7,7 @@ namespace Boss { namespace Msg {
 
 /** struct Boss::Msg::ManifestNotification
  *
- * @brief emitted in respone to Boss::Msg::Manifestation
+ * @brief emitted in response to Boss::Msg::Manifestation
  * to register a notification.
  * Multiple modules can register the same notification
  * and listen for Boss::Msg::Notification.

--- a/README.md
+++ b/README.md
@@ -329,3 +329,28 @@ particular channels to particular nodes will not be auto-closed
 by CLBOSS (they may still be closed by `lightningd` due to an
 HTLC timeout, or by the peer for any reason, or by you; this
 just suppresses CLBOSS).
+
+### `--clboss-min-channel-size=<satoshis>`
+
+Pass this option to `lightningd` to configure the minimum
+channel size CLBOSS should consider creating.
+
+The amount specified must be an ordinary number, and must be
+in satoshis unit, without any trailing units or other strings.
+
+The default is "500000", or 0.005 BTC.
+
+### `--clboss-max-channel-size=<satoshis>`
+
+Pass this option to `lightningd` to configure the maximum
+channel size CLBOSS should consider creating.
+
+The amount specified must be an ordinary number, and must be
+in satoshis unit, without any trailing units or other strings.
+
+The default is "16777215", or 0.16777215 BTC.
+
+Anything larger than this default is considered a large (or
+"wumbo") channel.
+Using wumbo-sized channels will require passing `lightningd` 
+the `--large-channels|--wumbo` option.


### PR DESCRIPTION
This PR aims to allow users to configure {min|max} channel sizes that CLBOSS should open. Motivation is wanting to permit CLBOSS to open larger channels.

This is presented as an advanced configuration option passed to `lighthingd` and if unset the current defaults remain.

Currently untested (CLBOSS doesn't seem to like my tiny regtest network of 2 nodes!) and no tests written. These may be added to this PR shortly if there is interest.

@ZmnSCPxj interested in your feedback on whether you want to see advanced config options like this in CLBOSS at all? The other alternative is to add some interior logic which opens larger channels if there is a large wallet balance in `lightningd`, or perhaps even uses a target "number of channels" to open e.g. ~5 channels. If you drop 0.1 BTC in, there won't be any wumbo channels, but if you drop 1 BTC in it might open one or two wumbo channels?

The final alternative is to do nothing at all, and CLBOSS will simply keep making many channels under the previous soft channel limit of 0.16...btc.