### PR TITLE
ChannelFinderByPopularity becomes aggressive when owned funds jumps significantly

### DIFF
--- a/Boss/Mod/ListfundsAnalyzer.cpp
+++ b/Boss/Mod/ListfundsAnalyzer.cpp
@@ -1,0 +1,71 @@
+#include"Boss/Mod/ListfundsAnalyzer.hpp"
+#include"Boss/Msg/ListfundsAnalyzedResult.hpp"
+#include"Boss/Msg/ListfundsResult.hpp"
+#include"Boss/log.hpp"
+#include"Ev/Io.hpp"
+#include"S/Bus.hpp"
+#include"Util/make_unique.hpp"
+#include"Util/stringify.hpp"
+
+namespace Boss { namespace Mod {
+
+class ListfundsAnalyzer::Impl {
+private:
+	S::Bus& bus;
+
+	void start() {
+		bus.subscribe<Msg::ListfundsResult
+			     >([this](Msg::ListfundsResult const& l) {
+			try {
+				return analyze(l);
+			} catch (Jsmn::TypeError const&) {
+				return Boss::log( bus, Error
+						, "ListfundsAnalyzer: Unexpected "
+						  "result from listfunds: "
+						  "outputs = %s, "
+						  "channels = %s"
+						, Util::stringify(l.outputs)
+							.c_str()
+						, Util::stringify(l.channels)
+							.c_str()
+						);
+			}
+		});
+	}
+
+	Ev::Io<void> analyze(Msg::ListfundsResult const& l) {
+		auto ar = Msg::ListfundsAnalyzedResult();
+
+		ar.total_owned = Ln::Amount::msat(0);
+
+		for (auto output : l.outputs) {
+			auto amt_s = std::string(output["amount_msat"]);
+			if (!Ln::Amount::valid_string(amt_s))
+				throw Jsmn::TypeError();
+			ar.total_owned += Ln::Amount(amt_s);
+		}
+
+		for (auto channel : l.channels) {
+			auto amt_s = std::string(channel["our_amount_msat"]);
+			if (!Ln::Amount::valid_string(amt_s))
+				throw Jsmn::TypeError();
+			ar.total_owned += Ln::Amount(amt_s);
+		}
+
+		return bus.raise(std::move(ar));
+	}
+
+public:
+	Impl() =delete;
+	Impl(Impl&&) =delete;
+
+	explicit
+	Impl(S::Bus& bus_) : bus(bus_) { start(); }
+};
+
+ListfundsAnalyzer::ListfundsAnalyzer(ListfundsAnalyzer&&) =default;
+ListfundsAnalyzer::~ListfundsAnalyzer() =default;
+ListfundsAnalyzer::ListfundsAnalyzer(S::Bus& bus)
+	: pimpl(Util::make_unique<Impl>(bus)) { }
+
+}}

--- a/Boss/Mod/ListfundsAnalyzer.hpp
+++ b/Boss/Mod/ListfundsAnalyzer.hpp
@@ -1,0 +1,29 @@
+#ifndef BOSS_MOD_LISTFUNDSANALYZER_HPP
+#define BOSS_MOD_LISTFUNDSANALYZER_HPP
+
+#include<memory>
+
+namespace S { class Bus; }
+
+namespace Boss { namespace Mod {
+
+/** class Boss::Mod::ListfundsAnalyzer
+ *
+ * @brief Module to analyze the result of `listfunds` command.
+ */
+class ListfundsAnalyzer {
+private:
+	class Impl;
+	std::unique_ptr<Impl> pimpl;
+
+public:
+	ListfundsAnalyzer() =delete;
+	ListfundsAnalyzer(ListfundsAnalyzer&&);
+	~ListfundsAnalyzer();
+	explicit
+	ListfundsAnalyzer(S::Bus& bus);
+};
+
+}}
+
+#endif /* !defined(BOSS_MOD_LISTFUNDSANALYZER_HPP) */

--- a/Boss/Mod/all.cpp
+++ b/Boss/Mod/all.cpp
@@ -37,6 +37,7 @@
 #include"Boss/Mod/InvoicePayer.hpp"
 #include"Boss/Mod/JitRebalancer.hpp"
 #include"Boss/Mod/JsonOutputter.hpp"
+#include"Boss/Mod/ListfundsAnalyzer.hpp"
 #include"Boss/Mod/ListfundsAnnouncer.hpp"
 #include"Boss/Mod/ListpaysHandler.hpp"
 #include"Boss/Mod/ListpeersAnalyzer.hpp"
@@ -131,6 +132,7 @@ std::shared_ptr<void> all( std::ostream& cout
 	all->install<ListpeersAnalyzer>(bus);
 	all->install<OnchainFeeMonitor>(bus, *waiter);
 	all->install<ListfundsAnnouncer>(bus);
+	all->install<ListfundsAnalyzer>(bus);
 	all->install<OnchainFundsAnnouncer>(bus);
 	all->install<OnchainFundsIgnorer>(bus);
 	all->install<ChannelCreateDestroyMonitor>(bus);

--- a/Boss/Msg/ListfundsAnalyzedResult.hpp
+++ b/Boss/Msg/ListfundsAnalyzedResult.hpp
@@ -1,0 +1,19 @@
+#ifndef BOSS_MSG_LISTFUNDSANALYZEDRESULT_HPP
+#define BOSS_MSG_LISTFUNDSANALYZEDRESULT_HPP
+
+#include"Ln/Amount.hpp"
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::ListfundsAnalyzedResult
+ *
+ * @brief The result from `listfunds`, analyzed.
+ */
+struct ListfundsAnalyzedResult {
+	/* Total funds owned by us, both onchain and offchain.  */
+	Ln::Amount total_owned;
+};
+
+}}
+
+#endif /* !defined(BOSS_MSG_LISTFUNDSANALYZEDRESULT_HPP) */

--- a/Makefile.am
+++ b/Makefile.am
@@ -173,6 +173,8 @@ libclboss_la_SOURCES = \
 	Boss/Mod/JitRebalancer.hpp \
 	Boss/Mod/JsonOutputter.cpp \
 	Boss/Mod/JsonOutputter.hpp \
+	Boss/Mod/ListfundsAnalyzer.cpp \
+	Boss/Mod/ListfundsAnalyzer.hpp \
 	Boss/Mod/ListfundsAnnouncer.cpp \
 	Boss/Mod/ListfundsAnnouncer.hpp \
 	Boss/Mod/ListpaysHandler.cpp \
@@ -275,6 +277,7 @@ libclboss_la_SOURCES = \
 	Boss/Msg/InternetOnline.hpp \
 	Boss/Msg/JsonCin.hpp \
 	Boss/Msg/JsonCout.hpp \
+	Boss/Msg/ListfundsAnalyzedResult.hpp \
 	Boss/Msg/ListfundsResult.hpp \
 	Boss/Msg/ListpeersAnalyzedResult.hpp \
 	Boss/Msg/ListpeersResult.hpp \


### PR DESCRIPTION
Fixes: #81

This allows the use-case where the user slowly trickles in money rather than give it a one-time big-time deposit.