### PR TITLE
Centralized size settings

### DIFF
--- a/Boss/Mod/AmountSettingsHandler.cpp
+++ b/Boss/Mod/AmountSettingsHandler.cpp
@@ -1,0 +1,178 @@
+#include"Boss/Mod/AmountSettingsHandler.hpp"
+#include"Boss/Msg/AmountSettings.hpp"
+#include"Boss/Msg/EndOfOptions.hpp"
+#include"Boss/Msg/ManifestOption.hpp"
+#include"Boss/Msg/Manifestation.hpp"
+#include"Boss/Msg/Option.hpp"
+#include"Boss/log.hpp"
+#include"Jsmn/Object.hpp"
+#include"S/Bus.hpp"
+#include"Util/make_unique.hpp"
+#include<assert.h>
+#include<sstream>
+#include<string>
+
+namespace {
+
+/* Default channel boundaries.  */
+auto const default_min_channel = Ln::Amount::sat(  500000);
+auto const default_max_channel = Ln::Amount::sat(16777215);
+
+/* Default amount to always leave onchain for future
+ * channel management actions.  */
+auto const default_reserve =     Ln::Amount::sat(   30000);
+
+/* The absolute lowest min_channel setting.  */
+auto const min_min_channel =     Ln::Amount::sat(  500000);
+/* How much larger the max_channel should be over the min_channel.  */
+auto const max_channel_factor = double(2.0);
+/* How much larger the channel-creation trigger should be over
+ * the min_channel.  */
+auto const trigger_factor = double(2.0);
+/* How much to add to the channel-creation trigger above, to get
+ * the amount to leave after creation.  */
+auto const additional_remaining = Ln::Amount::sat(20000);
+
+Ln::Amount parse_sats(Jsmn::Object value) {
+	auto is = std::istringstream(std::string(value));
+	auto sats = std::uint64_t();
+	is >> sats;
+	return Ln::Amount::sat(sats);
+}
+
+}
+
+namespace Boss { namespace Mod {
+
+class AmountSettingsHandler::Impl {
+private:
+	S::Bus& bus;
+	std::unique_ptr<Msg::AmountSettings> settings;
+
+	void start() {
+		settings->min_channel = default_min_channel;
+		settings->max_channel = default_max_channel;
+		settings->reserve = default_reserve;
+
+		bus.subscribe<Msg::Manifestation
+			     >([this](Msg::Manifestation const& _) {
+			assert(settings);
+			return bus.raise(Msg::ManifestOption{
+				"clboss-min-onchain",
+				Msg::OptionType_String,
+				Json::Out::direct(default_reserve.to_sat()),
+				"Target to leave this number of satoshis "
+				"onchain, putting the rest into channels."
+			}) + bus.raise(Msg::ManifestOption{
+				"clboss-min-channel",
+				Msg::OptionType_String,
+				Json::Out::direct(default_min_channel.to_sat()),
+				"Minimum size of channels to make."
+			}) + bus.raise(Msg::ManifestOption{
+				"clboss-max-channel",
+				Msg::OptionType_String,
+				Json::Out::direct(default_max_channel.to_sat()),
+				"Maximum size of channels to make."
+			});
+		});
+
+		bus.subscribe<Msg::Option
+			     >([this](Msg::Option o) {
+			assert(settings);
+			auto const& name = o.name;
+			if (name == "clboss-min-onchain") {
+				settings->reserve = parse_sats(o.value);
+				if (settings->reserve == default_reserve)
+					return Ev::lift();
+				return Boss::log( bus, Info
+						, "AmountSettingsHandler: "
+						  "Onchain reserve set by "
+						  "--clboss-min-onchain to "
+						  "%s satoshis."
+						, std::string(o.value).c_str()
+						);
+			} else if (name == "clboss-min-channel") {
+				settings->min_channel = parse_sats(o.value);
+				if (settings->min_channel == default_min_channel)
+					return Ev::lift();
+				return Boss::log( bus, Info
+						, "AmountSettingsHandler: "
+						  "Minimum channel size set by "
+						  "--clboss-min-channel to "
+						  "%s satoshis."
+						, std::string(o.value).c_str()
+						);
+			} else if (name == "clboss-max-channel") {
+				settings->max_channel = parse_sats(o.value);
+				if (settings->max_channel == default_max_channel)
+					return Ev::lift();
+				return Boss::log( bus, Info
+						, "AmountSettingsHandler: "
+						  "Maximum channel size set by "
+						  "--clboss-max-channel to "
+						  "%s satoshis."
+						, std::string(o.value).c_str()
+						);
+			}
+			return Ev::lift();
+		});
+
+		bus.subscribe<Msg::EndOfOptions
+			     >([this](Msg::EndOfOptions const& _) {
+			assert(settings);
+
+			auto act = Ev::lift();
+
+			/* Validate settings.  */
+			if (settings->min_channel < min_min_channel) {
+				settings->min_channel = min_min_channel;
+				act += Boss::log( bus, Info
+						, "AmountSettingsHandler: "
+						  "--clboss-min-channel too "
+						  "low, forced to %u."
+						, (unsigned int)
+						  min_min_channel.to_sat()
+						);
+			}
+			if (settings->max_channel < ( max_channel_factor
+						    * settings->min_channel
+						    )) {
+				settings->max_channel = ( max_channel_factor
+							* settings->min_channel
+							);
+				act += Boss::log( bus, Info
+						, "AmountSettingsHandler: "
+						  "--clboss-max-channel too "
+						  "low, forced to %u."
+						, (unsigned int)
+						  settings->max_channel.to_sat()
+						);
+			}
+
+			/* Compute the rest.  */
+			settings->min_amount = trigger_factor
+					     * settings->min_channel
+					     ;
+			settings->min_remaining = settings->min_amount
+						+ additional_remaining
+						;
+
+			/* Grab the settings and send it.  */
+			auto msg = std::move(settings);
+			return act + bus.raise(std::move(*msg));
+		});
+	}
+
+public:
+	Impl() =delete;
+	Impl(Impl&&) =delete;
+	Impl(Impl const&) =delete;
+
+	explicit
+	Impl( S::Bus& bus_
+	    ) : bus(bus_)
+	      , settings(Util::make_unique<Msg::AmountSettings>())
+	      { start(); }
+};
+
+}}

--- a/Boss/Mod/AmountSettingsHandler.hpp
+++ b/Boss/Mod/AmountSettingsHandler.hpp
@@ -1,0 +1,27 @@
+#ifndef BOSS_MOD_AMOUNTSETTINGSHANDLER_HPP
+#define BOSS_MOD_AMOUNTSETTINGSHANDLER_HPP
+
+#include<memory>
+
+namespace S { class Bus; }
+
+namespace Boss { namespace Mod {
+
+class AmountSettingsHandler {
+private:
+	class Impl;
+	std::unique_ptr<Impl> pimpl;
+
+public:
+	AmountSettingsHandler() =delete;
+	AmountSettingsHandler(AmountSettingsHandler const&) =delete;
+
+	AmountSettingsHandler(AmountSettingsHandler&&);
+
+	explicit
+	AmountSettingsHandler(S::Bus&);
+};
+
+}}
+
+#endif /* !defined(BOSS_MOD_AMOUNTSETTINGSHANDLER_HPP) */

--- a/Boss/Mod/ChannelCreator/Manager.hpp
+++ b/Boss/Mod/ChannelCreator/Manager.hpp
@@ -43,6 +43,10 @@ private:
 
 	std::unique_ptr<Boss::Mod::ChannelCreator::Reprioritizer> reprioritizer;
 
+	Ln::Amount min_amount;
+	Ln::Amount max_amount;
+	Ln::Amount min_remaining;
+
 	void start();
 	Ev::Io<void> on_request_channel_creation(Ln::Amount);
 

--- a/Boss/Mod/Initiator.cpp
+++ b/Boss/Mod/Initiator.cpp
@@ -3,6 +3,7 @@
 #include"Boss/Msg/CommandRequest.hpp"
 #include"Boss/Msg/CommandResponse.hpp"
 #include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/EndOfOptions.hpp"
 #include"Boss/Msg/Init.hpp"
 #include"Boss/Msg/ManifestOption.hpp"
 #include"Boss/Msg/Option.hpp"
@@ -166,6 +167,7 @@ public:
 			auto pre_act = Ev::lift();
 			if (params.has("options"))
 				pre_act += handle_options(params["options"]);
+			pre_act += bus.raise(Msg::EndOfOptions{});
 
 			auto configuration = params["configuration"];
 			if (!configuration.is_object())

--- a/Boss/Msg/AmountSettings.hpp
+++ b/Boss/Msg/AmountSettings.hpp
@@ -1,0 +1,32 @@
+#ifndef BOSS_MSG_AMOUNTSETTINGS_HPP
+#define BOSS_MSG_AMOUNTSETTINGS_HPP
+
+#include"Ln/Amount.hpp"
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::AmountSettings
+ *
+ * @brief Broadcast before `init` completes (before RPC
+ * and DB are available) with all the various settings
+ * related to how large the node is.
+ */
+struct AmountSettings {
+	/* Minimum and maximum channel size.  */
+	Ln::Amount min_channel;
+	Ln::Amount max_channel;
+	/* How much we will always definitely leave onchain for
+	 * various actions?  */
+	Ln::Amount reserve;
+	/* How much should be onchain in order to trigger channel
+	 * creation?
+	 */
+	Ln::Amount min_amount;
+	/* On channel creation, how much to leave onchain at minimum
+	 * for the next channel creation event?  */
+	Ln::Amount min_remaining;
+};
+
+}}
+
+#endif /* !defined(BOSS_MSG_AMOUNTSETTINGS_HPP) */

--- a/Boss/Msg/EndOfOptions.hpp
+++ b/Boss/Msg/EndOfOptions.hpp
@@ -1,0 +1,15 @@
+#ifndef BOSS_MSG_ENDOFOPTIONS_HPP
+#define BOSS_MSG_ENDOFOPTIONS_HPP
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::EndOfOptions
+ *
+ * @brief Raised at initialization, after all `Boss::Msg::Option`
+ * messages have been sent.
+ */
+struct EndOfOptions { };
+
+}}
+
+#endif /* !defined(BOSS_MSG_ENDOFOPTIONS_HPP) */

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,8 @@ libclboss_la_SOURCES = \
 	Boss/Main.hpp \
 	Boss/Mod/ActiveProber.cpp \
 	Boss/Mod/ActiveProber.hpp \
+	Boss/Mod/AmountSettingsHandler.cpp \
+	Boss/Mod/AmountSettingsHandler.hpp \
 	Boss/Mod/AutoDisconnector.cpp \
 	Boss/Mod/AutoDisconnector.hpp \
 	Boss/Mod/BlockTracker.cpp \
@@ -262,6 +264,7 @@ libclboss_la_SOURCES = \
 	Boss/ModG/Swapper.cpp \
 	Boss/ModG/Swapper.hpp \
 	Boss/Msg/AcceptSwapQuotation.hpp \
+	Boss/Msg/AmountSettings.hpp \
 	Boss/Msg/Begin.hpp \
 	Boss/Msg/Block.hpp \
 	Boss/Msg/ChannelCreateResult.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -272,6 +272,7 @@ libclboss_la_SOURCES = \
 	Boss/Msg/CommandRequest.hpp \
 	Boss/Msg/CommandResponse.hpp \
 	Boss/Msg/DbResource.hpp \
+	Boss/Msg/EndOfOptions.hpp \
 	Boss/Msg/ForwardFee.hpp \
 	Boss/Msg/Init.hpp \
 	Boss/Msg/InternetOnline.hpp \

--- a/tests/boss/test_channelcreationdecider.cpp
+++ b/tests/boss/test_channelcreationdecider.cpp
@@ -1,5 +1,6 @@
 #undef NDEBUG
 #include"Boss/Mod/ChannelCreationDecider.hpp"
+#include"Boss/Msg/AmountSettings.hpp"
 #include"Boss/Msg/ChannelFunds.hpp"
 #include"Boss/Msg/NeedsOnchainFunds.hpp"
 #include"Boss/Msg/OnchainFee.hpp"
@@ -57,6 +58,14 @@ int main() {
 	auto const HIGH_FEE = false;
 
 	auto code = Ev::lift().then([&]() {
+
+		/* Set up first.  */
+		auto msg = Boss::Msg::AmountSettings();
+		msg.reserve = Ln::Amount::sat(30000);
+		msg.min_amount = Ln::Amount::btc(0.010);
+		msg.min_remaining = Ln::Amount::btc(0.0105);
+		return bus.raise(msg);
+	}).then([&]() {
 
 		return onchain_funds(Ln::Amount::btc(1.0));;
 	}).then([&]() {


### PR DESCRIPTION
Closes: #74

This centralizes the size settings into a single module, which will then emit a message containing the size settings.  As noted in #86, other modules need information like the minimum channel size as well.

@willcl-ark
