### PR TITLE
Transmit RPC command requests over the `S::Bus`

### DIFF
--- a/Boss/Mod/ListpeersAnnouncer.hpp
+++ b/Boss/Mod/ListpeersAnnouncer.hpp
@@ -1,7 +1,9 @@
 #ifndef BOSS_MOD_LISTPEERSANNOUNCER_HPP
 #define BOSS_MOD_LISTPEERSANNOUNCER_HPP
 
-namespace Boss { namespace Mod { class Rpc; }}
+#include<memory>
+
+namespace Boss { namespace ModG { class RpcProxy; }}
 namespace S { class Bus; }
 
 namespace Boss { namespace Mod {
@@ -14,17 +16,15 @@ namespace Boss { namespace Mod {
 class ListpeersAnnouncer {
 private:
 	S::Bus& bus;
-	Boss::Mod::Rpc *rpc;
+	std::unique_ptr<Boss::ModG::RpcProxy> rpc;
 
 	void start();
 
 public:
 	ListpeersAnnouncer() =delete;
 	ListpeersAnnouncer(ListpeersAnnouncer const&) =delete;
-	ListpeersAnnouncer( S::Bus& bus_
-			  ) : bus(bus_)
-			    , rpc(nullptr)
-			    { start(); }
+	~ListpeersAnnouncer();
+	ListpeersAnnouncer(S::Bus& bus);
 };
 
 }}

--- a/Boss/Mod/RpcWrapper.cpp
+++ b/Boss/Mod/RpcWrapper.cpp
@@ -1,0 +1,101 @@
+#include"Boss/Mod/Rpc.hpp"
+#include"Boss/Mod/RpcWrapper.hpp"
+#include"Boss/Msg/Init.hpp"
+#include"Boss/Msg/RequestRpcCommand.hpp"
+#include"Boss/Msg/ResponseRpcCommand.hpp"
+#include"Boss/concurrent.hpp"
+#include"Ev/foreach.hpp"
+#include"S/Bus.hpp"
+#include"Util/make_unique.hpp"
+#include<vector>
+
+namespace Boss { namespace Mod {
+
+class RpcWrapper::Impl {
+private:
+	S::Bus& bus;
+
+	/*~ The core object that will actually handle
+	 * the command.
+	 */
+	Boss::Mod::Rpc* rpc;
+	/*~ Any pending requests that were received
+	 * before `Boss::Msg::Init` was.
+	 */
+	std::vector<Boss::Msg::RequestRpcCommand> pending;
+
+	void start() {
+		rpc = nullptr;
+
+		bus.subscribe<Msg::Init
+			     >([this](Msg::Init const& init) {
+			rpc = &init.rpc;
+
+			auto f = [ this
+				 ](Msg::RequestRpcCommand req) {
+				return handle_command(req);
+			};
+			/* Grab the contents of pending, to
+			 * ensure that no storage for it
+			 * remains allocated.
+			 */
+			return Boss::concurrent(
+				Ev::foreach(f, std::move(pending))
+			);
+		});
+
+		bus.subscribe<Msg::RequestRpcCommand
+			     >([this](Msg::RequestRpcCommand const& req) {
+			return Boss::concurrent(handle_command(req));
+		});
+	}
+
+	Ev::Io<void> handle_command(Msg::RequestRpcCommand const& req) {
+		if (!rpc) {
+			pending.push_back(req);
+			return Ev::lift();
+		}
+
+		auto requester = req.requester;
+		auto command = std::make_shared<std::string>(req.command);
+		auto params = std::make_shared<Json::Out>(req.params);
+
+		return Ev::lift().then([ this
+				       , requester
+				       , command
+				       , params
+				       ]() {
+			return rpc->command( *command
+					   , std::move(*params)
+					   ).then([ this
+						  , requester
+						  ](Jsmn::Object result) {
+				return bus.raise(Msg::ResponseRpcCommand{
+					requester, true, std::move(result), ""
+				});
+			}).catching<RpcError>([ this
+					      , requester
+					      ](RpcError const& e) {
+				return bus.raise(Msg::ResponseRpcCommand{
+					requester, false, e.error, e.command
+				});
+			});
+		});
+	}
+
+public:
+	Impl() =delete;
+	Impl(Impl&&) =delete;
+	Impl(Impl const&) =delete;
+
+	explicit
+	Impl(S::Bus& bus_) : bus(bus_) { start(); }
+};
+
+RpcWrapper::RpcWrapper(RpcWrapper&&) =default;
+RpcWrapper::~RpcWrapper() =default;
+
+RpcWrapper::RpcWrapper(S::Bus& bus)
+	: pimpl(Util::make_unique<Impl>(bus)) { }
+
+}}

--- a/Boss/Mod/RpcWrapper.hpp
+++ b/Boss/Mod/RpcWrapper.hpp
@@ -1,0 +1,38 @@
+#ifndef BOSS_MOD_RPCWRAPPER_HPP
+#define BOSS_MOD_RPCWRAPPER_HPP
+
+#include<memory>
+
+namespace S { class Bus; }
+
+namespace Boss { namespace Mod {
+
+/** class Boss::Mod::RpcWrapper
+ *
+ * @brief Handles RPC commands sent via the bus.
+ *
+ * @desc This module allows RPC commands to be
+ * sent via the bus, instead of the `Boss::Mod::Rpc`
+ * object being sent over the `Boss::Msg::Init`
+ * message.
+ * By using the bus, it is easier to test modules
+ * in isolation, since mocking the RPC.
+ */
+class RpcWrapper {
+private:
+	class Impl;
+	std::unique_ptr<Impl> pimpl;
+
+public:
+	RpcWrapper() =delete;
+	RpcWrapper(RpcWrapper const&) =delete;
+
+	RpcWrapper(RpcWrapper&&);
+	~RpcWrapper();
+	explicit
+	RpcWrapper(S::Bus& bus);
+};
+
+}}
+
+#endif /* BOSS_MOD_RPCWRAPPER_HPP */

--- a/Boss/Mod/all.cpp
+++ b/Boss/Mod/all.cpp
@@ -59,6 +59,7 @@
 #include"Boss/Mod/PeerStatistician.hpp"
 #include"Boss/Mod/Reconnector.hpp"
 #include"Boss/Mod/RegularActiveProbe.hpp"
+#include"Boss/Mod/RpcWrapper.hpp"
 #include"Boss/Mod/SelfUptimeMonitor.hpp"
 #include"Boss/Mod/SendpayResultMonitor.hpp"
 #include"Boss/Mod/StatusCommand.hpp"
@@ -108,6 +109,7 @@ std::shared_ptr<void> all( std::ostream& cout
 							   );
 	all->install<JsonOutputter>(cout, bus);
 	all->install<CommandReceiver>(bus);
+	all->install<RpcWrapper>(bus);
 
 	/* Startup.  */
 	all->install<Manifester>(bus);

--- a/Boss/ModG/RpcProxy.cpp
+++ b/Boss/ModG/RpcProxy.cpp
@@ -1,0 +1,39 @@
+#include"Boss/Mod/Rpc.hpp"
+#include"Boss/ModG/RpcProxy.hpp"
+#include"Boss/Msg/RequestRpcCommand.hpp"
+#include"Boss/Msg/ResponseRpcCommand.hpp"
+#include"Ev/Io.hpp"
+#include"Jsmn/Object.hpp"
+#include"Json/Out.hpp"
+#include"S/Bus.hpp"
+
+namespace Boss { namespace ModG {
+
+RpcProxy::~RpcProxy() =default;
+
+RpcProxy::RpcProxy(S::Bus& bus)
+	: core( bus
+	      , [](Msg::RequestRpcCommand& m, void* p) {
+			m.requester = p;
+		}
+	      , [](Msg::ResponseRpcCommand& m) {
+			return m.requester;
+		}
+	      ) { }
+
+Ev::Io<Jsmn::Object>
+RpcProxy::command( std::string const& command
+		 , Json::Out params
+		 ) {
+	return core.execute(Msg::RequestRpcCommand{
+		nullptr, command, params
+	}).then([](Msg::ResponseRpcCommand resp) {
+		if (!resp.succeeded)
+			throw Mod::RpcError( std::move(resp.command)
+					   , std::move(resp.result)
+					   );
+		return Ev::lift(std::move(resp.result));
+	});
+}
+
+}}

--- a/Boss/ModG/RpcProxy.hpp
+++ b/Boss/ModG/RpcProxy.hpp
@@ -1,0 +1,43 @@
+#ifndef BOSS_MODG_RPCPROXY_HPP
+#define BOSS_MODG_RPCPROXY_HPP
+
+#include"Boss/ModG/ReqResp.hpp"
+#include<string>
+
+namespace Boss { namespace Msg { struct RequestRpcCommand; }}
+namespace Boss { namespace Msg { struct ResponseRpcCommand; }}
+namespace Ev { template<typename a> class Io; }
+namespace Jsmn { class Object; }
+namespace Json { class Out; }
+namespace S { class Bus; }
+
+namespace Boss { namespace ModG {
+
+/** class Boss::ModG::RpcProxy
+ *
+ * @brief Utility object to act as the `Boss::Mod::Rpc`,
+ * but utilizing the `S::Bus` underneath.
+ */
+class RpcProxy {
+private:
+	Boss::ModG::ReqResp<Msg::RequestRpcCommand, Msg::ResponseRpcCommand> core;
+
+public:
+	RpcProxy() =delete;
+	~RpcProxy();
+
+	explicit
+	RpcProxy(S::Bus&);
+
+	/*~ Perform the RPC, possibly throwing
+	 * Boss::Mod::RpcError in case the
+	 * C-Lightning RPC threw an error.
+	 */
+	Ev::Io<Jsmn::Object> command( std::string const& command
+				    , Json::Out params
+				    );
+};
+
+}}
+
+#endif /* BOSS_MODG_RPCPROXY_HPP */

--- a/Boss/Msg/RequestRpcCommand.hpp
+++ b/Boss/Msg/RequestRpcCommand.hpp
@@ -1,0 +1,28 @@
+#ifndef BOSS_MSG_REQUESTRPCCOMMAND_HPP
+#define BOSS_MSG_REQUESTRPCCOMMAND_HPP
+
+#include"Json/Out.hpp"
+#include<string>
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::RequestRpcCommand
+ *
+ * @brief Requests an RPC command to be sent to the
+ * `lightningd`.
+ * This is handled by the `Boss::Mod::RpcWrapper`.
+ * The result of the command will then be broadcast
+ * via `Boss::Msg::ResponseRpcCommand`.
+ */
+struct RequestRpcCommand {
+	/*~ The object that requested the RPC command.  */
+	void* requester;
+	/*~ The command to execute.  */
+	std::string command;
+	/*~ The parameters to the command.  */
+	Json::Out params;
+};
+
+}}
+
+#endif /* BOSS_MSG_REQUESTRPCCOMMAND_HPP */

--- a/Boss/Msg/ResponseRpcCommand.hpp
+++ b/Boss/Msg/ResponseRpcCommand.hpp
@@ -1,0 +1,29 @@
+#ifndef BOSS_MSG_RESPONSERPCCOMMAND_HPP
+#define BOSS_MSG_RESPONSERPCCOMMAND_HPP
+
+#include"Jsmn/Object.hpp"
+#include<string>
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::ResponseRpcCommand
+ *
+ * @brief Broadcast in response to `Boss::Msg::RequestRpcCommand`,
+ * after the corresponding command has succeeded or failed.
+ */
+struct ResponseRpcCommand {
+	/*~ The object that requested the RPC command.  */
+	void* requester;
+	/*~ True if the command succeded.  */
+	bool succeeded;
+	/*~ Result if succeeded, or the error if failed.  */
+	Jsmn::Object result;
+	/*~ The command that failed if it failed, empty if the
+	 * command succeeded.
+	 */
+	std::string command;
+};
+
+}}
+
+#endif /* BOSS_MSG_RESPONSERPCCOMMAND_HPP */

--- a/Makefile.am
+++ b/Makefile.am
@@ -240,6 +240,8 @@ libclboss_la_SOURCES = \
 	Boss/Mod/RegularActiveProbe.hpp \
 	Boss/Mod/Rpc.cpp \
 	Boss/Mod/Rpc.hpp \
+	Boss/Mod/RpcWrapper.cpp \
+	Boss/Mod/RpcWrapper.hpp \
 	Boss/Mod/SelfUptimeMonitor.cpp \
 	Boss/Mod/SelfUptimeMonitor.hpp \
 	Boss/Mod/SendpayResultMonitor.cpp \
@@ -328,6 +330,7 @@ libclboss_la_SOURCES = \
 	Boss/Msg/RequestNewaddr.hpp \
 	Boss/Msg/RequestPeerMetrics.hpp \
 	Boss/Msg/RequestPeerStatistics.hpp \
+	Boss/Msg/RequestRpcCommand.hpp \
 	Boss/Msg/RequestSelfUptime.hpp \
 	Boss/Msg/ResponseConnect.hpp \
 	Boss/Msg/ResponseDowser.hpp \
@@ -338,6 +341,7 @@ libclboss_la_SOURCES = \
 	Boss/Msg/ResponseNewaddr.hpp \
 	Boss/Msg/ResponsePeerMetrics.hpp \
 	Boss/Msg/ResponsePeerStatistics.hpp \
+	Boss/Msg/ResponseRpcCommand.hpp \
 	Boss/Msg/ResponseSelfUptime.hpp \
 	Boss/Msg/RpcCommandHook.hpp \
 	Boss/Msg/SendpayResult.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -265,6 +265,8 @@ libclboss_la_SOURCES = \
 	Boss/ModG/Detail/ReqRespBase.cpp \
 	Boss/ModG/Detail/ReqRespBase.hpp \
 	Boss/ModG/ReqResp.hpp \
+	Boss/ModG/RpcProxy.cpp \
+	Boss/ModG/RpcProxy.hpp \
 	Boss/ModG/Swapper.cpp \
 	Boss/ModG/Swapper.hpp \
 	Boss/Msg/AcceptSwapQuotation.hpp \


### PR DESCRIPTION
Internal restructuring to move RPC command requests over the `S::Bus`, so that RPC-users can have the RPC mocked in module-level tests.