### PR TITLE
Boss/Mod/AvailableRpcCommandsAnnouncer.cpp: New module to announce the commands found on this node.

### DIFF
--- a/Boss/Mod/AvailableRpcCommandsAnnouncer.cpp
+++ b/Boss/Mod/AvailableRpcCommandsAnnouncer.cpp
@@ -1,0 +1,153 @@
+#include"Boss/Mod/AvailableRpcCommandsAnnouncer.hpp"
+#include"Boss/Mod/Rpc.hpp"
+#include"Boss/ModG/RpcProxy.hpp"
+#include"Boss/Msg/Begin.hpp"
+#include"Boss/Msg/AvailableRpcCommands.hpp"
+#include"Boss/concurrent.hpp"
+#include"Boss/log.hpp"
+#include"Ev/Io.hpp"
+#include"Json/Out.hpp"
+#include"Util/make_unique.hpp"
+#include<sstream>
+
+namespace Boss { namespace Mod {
+
+class AvailableRpcCommandsAnnouncer::Impl {
+private:
+	ModG::RpcProxy rpc;
+	void start(S::Bus& bus) {
+		bus.subscribe<Msg::Begin
+			     >([this, &bus](Msg::Begin const&) {
+			return Boss::concurrent(on_begin(bus));
+		});
+	}
+
+	Ev::Io<void> on_begin(S::Bus& bus) {
+		return rpc.command( "help"
+				  , Json::Out::empty_object()
+				  ).then([&bus](Jsmn::Object res) {
+
+			if (!res.is_object())
+				return error( bus, res
+					    , "Result not an object"
+					    );
+			if (!res.has("help"))
+				return error( bus, res
+					    , "No `help` field"
+					    );
+			auto j_help = res["help"];
+			if (!j_help.is_array())
+				return error( bus, j_help
+					    , "`help` field is not an "
+					      "array"
+					    );
+
+			auto msg = Boss::Msg::AvailableRpcCommands{};
+			auto& table = msg.commands;
+
+			auto num_commands = std::size_t(0);
+
+			for (auto j_cmd : j_help) {
+				if (!j_cmd.is_object())
+					return error( bus, j_cmd
+						    , "Command entry is "
+						      "not an object"
+						    );
+				if (!j_cmd.has("command"))
+					continue;
+				auto j_full_usage = j_cmd["command"];
+				if (!j_full_usage.is_string())
+					continue;
+				auto category = std::string("");
+				if (j_cmd.has("category")) {
+					auto j_category = j_cmd["category"];
+					if (j_category.is_string())
+						category = std::string(j_category);
+				}
+
+				auto full_usage = std::string(j_full_usage);
+				auto command = std::string();
+				auto usage = std::string();
+				split_usage(command, usage, full_usage);
+
+				table[command] = Msg::AvailableRpcCommands::Desc{
+					std::move(category), std::move(usage)
+				};
+				++num_commands;
+			}
+
+			return Boss::log( bus, Debug
+					, "AvailableRpcCommandsAnnouncer: "
+					  "Node has %zu commands."
+					, num_commands
+					)
+			     + bus.raise(msg)
+			     ;
+		}).catching<RpcError>([&bus](RpcError const& e) {
+			return Boss::log( bus, Error
+					, "AvailableRpcCommandsAnnouncer: "
+					  "Command `help` failed!? "
+					  "Error: %s"
+					, e.error.direct_text().c_str()
+					);
+		});
+	}
+
+	static
+	Ev::Io<void> error( S::Bus& bus
+			  , Jsmn::Object const& obj
+			  , char const* message
+			  ) {
+		return Boss::log( bus, Error
+				, "AvailableRpcCommandsAnnouncer: "
+				  "Unexpected result from `help`: "
+				  "%s: %s"
+				, message
+				, obj.direct_text().c_str()
+				);
+	}
+
+	static
+	void split_usage( std::string& command
+			, std::string& usage
+			, std::string const& full_usage
+			) {
+		auto s_command = std::ostringstream();
+		auto s_usage = std::ostringstream();
+		auto input = std::istringstream(full_usage);
+		while (input && !input.eof()) {
+			auto c = input.get();
+			if (input.eof())
+				break;
+
+			if (c == ' ') {
+				while (input && !input.eof()) {
+					c = input.get();
+					if (input.eof())
+						break;
+					s_usage.put(c);
+				}
+				break;
+			}
+			s_command.put(c);
+		}
+		command = s_command.str();
+		usage = s_usage.str();
+	}
+
+public:
+	Impl(S::Bus& bus) : rpc(bus) { start(bus); }
+	Impl(Impl const&) =delete;
+	Impl(Impl&&) =delete;
+};
+
+AvailableRpcCommandsAnnouncer::AvailableRpcCommandsAnnouncer(AvailableRpcCommandsAnnouncer&&)
+	=default;
+AvailableRpcCommandsAnnouncer::~AvailableRpcCommandsAnnouncer()
+	=default;
+
+AvailableRpcCommandsAnnouncer::AvailableRpcCommandsAnnouncer(S::Bus& bus)
+	: pimpl(Util::make_unique<Impl>(bus)) { }
+
+
+}}

--- a/Boss/Mod/AvailableRpcCommandsAnnouncer.hpp
+++ b/Boss/Mod/AvailableRpcCommandsAnnouncer.hpp
@@ -1,0 +1,37 @@
+#ifndef BOSS_MOD_AVAILABLERPCCOMMANDSANNOUNCER_HPP
+#define BOSS_MOD_AVAILABLERPCCOMMANDSANNOUNCER_HPP
+
+#include<memory>
+
+namespace S { class Bus; }
+
+namespace Boss { namespace Mod {
+
+/** class Boss::Mod::AvailableRpcCommandsAnnouncer
+ *
+ * @brief At startup, execute `help` on the node
+ * and find out the commands that are available on
+ * the C-Lightning node, and announce them via the
+ * `Boss::Msg::AvailableRpcCommands` message.
+ * This is useful to automatically adapt to changes
+ * in version of the C-Lightning node, or the
+ * existence/nonexistence of particular plugins.
+ */
+class AvailableRpcCommandsAnnouncer {
+private:
+	class Impl;
+	std::unique_ptr<Impl> pimpl;
+
+public:
+	AvailableRpcCommandsAnnouncer() =delete;
+
+	AvailableRpcCommandsAnnouncer(AvailableRpcCommandsAnnouncer&&);
+	~AvailableRpcCommandsAnnouncer();
+
+	explicit
+	AvailableRpcCommandsAnnouncer(S::Bus& bus);
+};
+
+}}
+
+#endif /* !defined(BOSS_MOD_AVAILABLERPCCOMMANDSANNOUNCER_HPP) */

--- a/Boss/Mod/all.cpp
+++ b/Boss/Mod/all.cpp
@@ -1,6 +1,7 @@
 #include"Boss/Mod/ActiveProber.hpp"
 #include"Boss/Mod/AmountSettingsHandler.hpp"
 #include"Boss/Mod/AutoDisconnector.hpp"
+#include"Boss/Mod/AvailableRpcCommandsAnnouncer.hpp"
 #include"Boss/Mod/BlockTracker.hpp"
 #include"Boss/Mod/BoltzSwapper/Main.hpp"
 #include"Boss/Mod/ChannelCandidateInvestigator/Main.hpp"
@@ -110,6 +111,7 @@ std::shared_ptr<void> all( std::ostream& cout
 	all->install<JsonOutputter>(cout, bus);
 	all->install<CommandReceiver>(bus);
 	all->install<RpcWrapper>(bus);
+	all->install<AvailableRpcCommandsAnnouncer>(bus);
 
 	/* Startup.  */
 	all->install<Manifester>(bus);

--- a/Boss/Msg/AvailableRpcCommands.hpp
+++ b/Boss/Msg/AvailableRpcCommands.hpp
@@ -1,0 +1,27 @@
+#ifndef BOSS_MSG_AVAILABLERPCCOMMANDS_HPP
+#define BOSS_MSG_AVAILABLERPCCOMMANDS_HPP
+
+#include<map>
+#include<string>
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::AvailableRpcCommands
+ *
+ * @brief Broadcast at startup, containing the commands
+ * available on the managed C-Lightning node, plus the
+ * usage of the commands.
+ */
+struct AvailableRpcCommands {
+	struct Desc {
+		std::string category;
+		/*~ Does not include command name.  */
+		std::string usage;
+	};
+	/*~ Key is the command name.  */
+	std::map<std::string, Desc> commands;
+};
+
+}}
+
+#endif /* BOSS_MSG_AVAILABLERPCCOMMANDS_HPP */

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,8 @@ libclboss_la_SOURCES = \
 	Boss/Mod/AmountSettingsHandler.hpp \
 	Boss/Mod/AutoDisconnector.cpp \
 	Boss/Mod/AutoDisconnector.hpp \
+	Boss/Mod/AvailableRpcCommandsAnnouncer.cpp \
+	Boss/Mod/AvailableRpcCommandsAnnouncer.hpp \
 	Boss/Mod/BlockTracker.cpp \
 	Boss/Mod/BlockTracker.hpp \
 	Boss/Mod/BoltzSwapper/Env.cpp \
@@ -271,6 +273,7 @@ libclboss_la_SOURCES = \
 	Boss/ModG/Swapper.hpp \
 	Boss/Msg/AcceptSwapQuotation.hpp \
 	Boss/Msg/AmountSettings.hpp \
+	Boss/Msg/AvailableRpcCommands.hpp \
 	Boss/Msg/Begin.hpp \
 	Boss/Msg/Block.hpp \
 	Boss/Msg/ChannelCreateResult.hpp \
@@ -556,6 +559,7 @@ TESTS = \
 	tests/boltz/test_match_lockscript \
 	tests/boss/channelcandidateinvestigator/test_gumshoe \
 	tests/boss/channelcandidateinvestigator/test_secretary \
+	tests/boss/test_availablerpccommandsannouncer \
 	tests/boss/test_channelcreationdecider \
 	tests/boss/test_channelcreator_planner \
 	tests/boss/test_channelcreator_rearrangerbysize \

--- a/tests/boss/test_availablerpccommandsannouncer.cpp
+++ b/tests/boss/test_availablerpccommandsannouncer.cpp
@@ -1,0 +1,98 @@
+#undef NDEBUG
+#include"Boss/Mod/AvailableRpcCommandsAnnouncer.hpp"
+#include"Boss/Msg/AvailableRpcCommands.hpp"
+#include"Boss/Msg/Begin.hpp"
+#include"Boss/Msg/RequestRpcCommand.hpp"
+#include"Boss/Msg/ResponseRpcCommand.hpp"
+#include"Ev/Io.hpp"
+#include"Ev/start.hpp"
+#include"Ev/yield.hpp"
+#include"Jsmn/Object.hpp"
+#include"S/Bus.hpp"
+#include<assert.h>
+#include<sstream>
+
+namespace {
+
+auto const help = std::string(R"JSON(
+{ "help":
+  [ { "command": "clboss-status"
+    , "category": "plugin"
+    }
+  , { "command": "clboss-ignore-onchain [hours]"
+    , "category": "plugin"
+    }
+  , { "command": "clboss-unmanage nodeid tags"
+    , "category": "plugin"
+    }
+  ]
+}
+)JSON");
+
+}
+
+int main() {
+	auto bus = S::Bus();
+	auto mod = Boss::Mod::AvailableRpcCommandsAnnouncer(bus);
+
+	/* Mock the `help` command.  */
+	auto help_flag = false;
+	bus.subscribe<Boss::Msg::RequestRpcCommand
+		     >([&](Boss::Msg::RequestRpcCommand const& m) {
+		/* Make sure it only happens once.  */
+		assert(m.command == "help");
+		assert(!help_flag);
+
+		help_flag = true;
+
+		auto j_help = Jsmn::Object();
+		auto s_help = std::istringstream(help);
+		s_help >> j_help;
+
+		auto response = Boss::Msg::ResponseRpcCommand();
+		response.requester = m.requester;
+		response.succeeded = true;
+		response.result = std::move(j_help);
+
+		return bus.raise(std::move(response));
+	});
+
+	/* Wait for the `AvailableRpcCommands`.  */
+	auto available_flag = false;
+	bus.subscribe<Boss::Msg::AvailableRpcCommands
+		     >([&](Boss::Msg::AvailableRpcCommands const& m) {
+		/* Make sure this only happens once.  */
+		assert(!available_flag);
+		available_flag = true;
+
+		/* Checks.  */
+		auto commands = m.commands;
+		assert(commands.count("clboss-status") != 0);
+		assert(commands.count("clboss-ignore-onchain") != 0);
+		assert(commands.count("clboss-unmanage") != 0);
+		assert(commands["clboss-status"].usage == "");
+		assert(commands["clboss-ignore-onchain"].usage == "[hours]");
+		assert(commands["clboss-unmanage"].usage == "nodeid tags");
+
+		return Ev::lift();
+	});
+
+	auto code = Ev::lift().then([&]() {
+		return bus.raise(Boss::Msg::Begin{});
+	}).then([&]() {
+		/* Let the module execute.  */
+		return Ev::yield() + Ev::yield() + Ev::yield() + Ev::yield()
+		     + Ev::yield() + Ev::yield() + Ev::yield() + Ev::yield()
+		     + Ev::yield() + Ev::yield() + Ev::yield() + Ev::yield()
+		     + Ev::yield() + Ev::yield() + Ev::yield() + Ev::yield()
+		     + Ev::yield() + Ev::yield() + Ev::yield() + Ev::yield()
+		     + Ev::yield() + Ev::yield() + Ev::yield() + Ev::yield()
+		     ;
+	}).then([&]() {
+		assert(help_flag);
+		assert(available_flag);
+		return Ev::lift(0);
+	});
+
+	return Ev::start(code);
+}


### PR DESCRIPTION
This will allow CLBOSS to figure out what commands (and parameters) the
specific C-Lightning node being managed has, and adapt accordingly.

This is relevant to both #105 (which uses a parameter that is new in 0.10.1) and #107 (so we can adapt to whichever API the node has).