### PR TITLE
Sqlite3/Db.cpp: enable SQLite extended result codes

### DIFF
--- a/Sqlite3/Db.cpp
+++ b/Sqlite3/Db.cpp
@@ -33,6 +33,16 @@ public:
 				msg
 			);
 		}
+		res = sqlite3_extended_result_codes(connection, 1);
+		if (res != SQLITE_OK) {
+			auto msg = std::string(sqlite3_errmsg(connection));
+			sqlite3_close_v2(connection);
+			connection = nullptr;
+			throw std::runtime_error(
+				std::string("Sqlite3::Db: sqlite3_extended_result_codes: ") +
+				msg
+			);
+		}
 		res = sqlite3_exec( connection, "PRAGMA foreign_keys = ON;"
 				  , NULL, NULL, NULL
 				  );


### PR DESCRIPTION
With this change, we get more fine-grained error messages if something goes wrong in the course of communicating with the SQLite database. To pick some random examples, the error codes SQLITE_IOERR_NOMEM, SQLITE_IOERR_CORRUPTFS or SQLITE_IOERR_FSYNC are way more specific than just a plain SQLITE_IOERR, and the corresponding error messages generated by sqlite3_errstr() will hence give a better hint to the user (or also to the developers, if an error report is sent) what the cause for a failure is.

See the SQLite documentation
https://www.sqlite.org/c3ref/extended_result_codes.html
https://www.sqlite.org/c3ref/c_abort_rollback.html

> In its default configuration, SQLite API routines return one of 30 integer result codes. However, experience has shown that many of these result codes are too coarse-grained. They do not provide as much information about problems as programmers might like. In an effort to address this, newer versions of SQLite (version 3.3.8 2006-10-09 and later) include support for additional result codes that provide more detailed information about errors.

(Note that corresponding PRs have also been opened and merged on Bitcoin Core and c-lightning within the last few months: https://github.com/bitcoin/bitcoin/pull/23112, https://github.com/ElementsProject/lightning/pull/5029)