### PR TITLE
configure.ac: Default `CXXFLAGS` to just `-O2`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ You will then need to modify your `lightning.conf` to add the
 path to `which clboss` as a `plugin` or `important-plugin` of
 `lightningd`.
 
+Usually, autotools-based projects like CLBOSS will default
+to using `-g -O2` for compilation flags, where `-g` causes
+the compiler to include debug info.
+CLBOSS changes this default to `-O2` so that users by default
+get a binary without debug symbols (a binary with debug symbols
+would be 20x larger!), but if it matters to you, you can
+override the CLBOSS default via `CXXFLAGS`, such as:
+
+    ./configure CXXFLAGS="-g -O2"  # or whatever flags you like
+
+And if your build machine has more than 1 core, you probably
+want to pass in the `-j` option to `make`, too:
+
+    make -j4  # or how many cores you want to build on
+
 From a git clone, you first need to execute:
 
     autoreconf -i

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,22 @@ LT_INIT([disable-shared])
 m4_pattern_forbid([^PKG_])
 
 # Checks for programs.
+# If CXXFLAGS is unset, remove the -g
+# that AC_PROG_CXX adds to it.
+clboss_set_CXXFLAGS=${CXXFLAGS+y}
 AC_PROG_CXX
+AS_IF([test ${clboss_set_CXXFLAGS}], [
+	# AC_PROG_CXX will respect the user-given CXXFLAGS
+	:
+],[
+	# AC_PROG_CXX will default to `-g -O2` if g++,
+	# or `-g` otherwise.
+	AS_IF([test x"$GXX" = x"yes"], [
+		CXXFLAGS="-O2"
+	], [
+		CXXFLAGS=""
+	])
+])
 AX_CXX_COMPILE_STDCXX_11
 AC_LANG([C++])
 


### PR DESCRIPTION
Closes: #138