### PR TITLE
Update to handle JSON-RPC amounts in either the old or new conventions

### DIFF
--- a/Boss/Mod/ActiveProber.cpp
+++ b/Boss/Mod/ActiveProber.cpp
@@ -137,9 +137,9 @@ private:
 						chan0 = Ln::Scid(std::string(
 							c["short_channel_id"]
 						));
-						cap0 = Ln::Amount(std::string(
+						cap0 = Ln::Amount::object(
 							c["spendable_msat"]
-						));
+						);
 						break;
 					}
 
@@ -263,9 +263,9 @@ private:
 				chan1 = Ln::Scid(std::string(
 					hop1["channel"]
 				));
-				amount1 = Ln::Amount(std::string(
+				amount1 = Ln::Amount::object(
 					hop1["amount_msat"]
-				));
+				);
 				delay1 = std::uint32_t(double(
 					hop1["delay"]
 				));

--- a/Boss/Mod/ChannelFundsComputer.cpp
+++ b/Boss/Mod/ChannelFundsComputer.cpp
@@ -23,12 +23,9 @@ ChannelFundsComputer::on_listfunds(Msg::ListfundsResult const& r) {
 			if (!chan.is_object() || !chan.has("our_amount_msat"))
 				continue;
 			auto amount_j = chan["our_amount_msat"];
-			if (!amount_j.is_string())
+			if (!Ln::Amount::valid_object(amount_j))
 				continue;
-			auto amount_s = std::string(amount_j);
-			if (!Ln::Amount::valid_string(amount_s))
-				continue;
-			auto amount = Ln::Amount(amount_s);
+			auto amount = Ln::Amount::object(amount_j);
 			total += amount;
 
 			if (!chan.has("connected"))

--- a/Boss/Mod/Dowser.cpp
+++ b/Boss/Mod/Dowser.cpp
@@ -243,10 +243,9 @@ private:
 				   )
 					continue;
 				auto amt_j = chan["amount_msat"];
-				if (!amt_j.is_string())
+				if (!Ln::Amount::valid_object(amt_j))
 					continue;
-				auto amt_s = std::string(amt_j);
-				return Ev::lift(Ln::Amount(amt_s));
+				return Ev::lift(Ln::Amount::object(amt_j));
 			}
 
 			/* The channel *can* disappear between the time

--- a/Boss/Mod/EarningsRebalancer.cpp
+++ b/Boss/Mod/EarningsRebalancer.cpp
@@ -173,12 +173,12 @@ private:
 					   )
 						continue;
 
-					auto to_us = Ln::Amount(std::string(
+					auto to_us = Ln::Amount::object(
 						c["to_us_msat"]
-					));
-					auto c_total = Ln::Amount(std::string(
+					);
+					auto c_total = Ln::Amount::object(
 						c["total_msat"]
-					));
+					);
 					auto to_them = c_total - to_us;
 
 					spendable += to_us;

--- a/Boss/Mod/FeeModderByBalance.cpp
+++ b/Boss/Mod/FeeModderByBalance.cpp
@@ -180,12 +180,12 @@ private:
 						if (state != "CHANNELD_NORMAL")
 							continue;
 						found = true;
-						to_us = Ln::Amount(std::string(
+						to_us = Ln::Amount::object(
 							c["to_us_msat"]
-						));
-						total = Ln::Amount(std::string(
+						);
+						total = Ln::Amount::object(
 							c["total_msat"]
-						));
+						);
 						break;
 					}
 					if (found)

--- a/Boss/Mod/FeeModderBySize.cpp
+++ b/Boss/Mod/FeeModderBySize.cpp
@@ -175,9 +175,9 @@ private:
 			auto source = Ln::NodeId(std::string(
 				channel["source"]
 			));
-			auto amount = Ln::Amount(std::string(
+			auto amount = Ln::Amount::object(
 				channel["amount_msat"]
-			));
+			);
 			(*capacities)[source] += amount;
 
 			return load_capacities_loop( pchannels

--- a/Boss/Mod/ForwardFeeMonitor.cpp
+++ b/Boss/Mod/ForwardFeeMonitor.cpp
@@ -43,9 +43,9 @@ void ForwardFeeMonitor::start() {
 			out_scid = Ln::Scid(std::string(
 				payload["out_channel"]
 			));
-			fee = Ln::Amount(std::string(
+			fee = Ln::Amount::object(
 				payload["fee_msat"]
-			));
+			);
 			resolution_time = double(payload["resolved_time"])
 					- double(payload["received_time"])
 					;

--- a/Boss/Mod/FundsMover/Attempter.cpp
+++ b/Boss/Mod/FundsMover/Attempter.cpp
@@ -171,9 +171,9 @@ private:
 				hop1 = Ln::Scid(std::string(
 					hop1_data["channel"]
 				));
-				*hop1_amount = Ln::Amount(std::string(
+				*hop1_amount = Ln::Amount::object(
 					hop1_data["amount_msat"]
-				));
+				);
 				*hop1_delay = std::uint32_t(double(
 					hop1_data["delay"]
 				));

--- a/Boss/Mod/HtlcAcceptor.cpp
+++ b/Boss/Mod/HtlcAcceptor.cpp
@@ -124,9 +124,9 @@ private:
 			rv->incoming_payload = Util::Str::hexread(std::string(
 				onion["payload"]
 			));
-			rv->incoming_amount = Ln::Amount(std::string(
-				htlc["amount"]
-			));
+			rv->incoming_amount = Ln::Amount::object(
+				htlc["amount_msat"]
+			);
 			rv->incoming_cltv = std::uint32_t(double(
 				htlc["cltv_expiry"]
 			));
@@ -142,9 +142,9 @@ private:
 				rv->next_channel = Ln::Scid(std::string(
 					onion["short_channel_id"]
 				));
-				rv->next_amount = Ln::Amount(std::string(
-					onion["forward_amount"]
-				));
+				rv->next_amount = Ln::Amount::object(
+					onion["forward_msat"]
+				);
 				rv->next_cltv = std::uint32_t(double(
 					onion["outgoing_cltv_value"]
 				));

--- a/Boss/Mod/InitialRebalancer.cpp
+++ b/Boss/Mod/InitialRebalancer.cpp
@@ -228,13 +228,13 @@ private:
 		   )
 			return;
 		/* FIXME: Handle reserves.  */
-		auto to_us = Ln::Amount(std::string(c["to_us_msat"]));
-		auto total = Ln::Amount(std::string(c["total_msat"]));
+		auto to_us = Ln::Amount::object(c["to_us_msat"]);
+		auto total = Ln::Amount::object(c["total_msat"]);
 		auto to_them = total - to_us;
 		for (auto h : c["htlcs"])
-			to_them -= Ln::Amount(std::string(
+			to_them -= Ln::Amount::object(
 				h["amount_msat"]
-			));
+		);
 		a_spendable += to_us;
 		a_receivable += to_them;
 		a_total += total;

--- a/Boss/Mod/JitRebalancer.cpp
+++ b/Boss/Mod/JitRebalancer.cpp
@@ -326,14 +326,12 @@ private:
 						);
 						if (state != "CHANNELD_NORMAL")
 							continue;
-						to_us += Ln::Amount(
-							std::string(
+						to_us += Ln::Amount::object(
 							c["to_us_msat"]
-						));
-						capacity += Ln::Amount(
-							std::string(
+						);
+						capacity += Ln::Amount::object(
 							c["total_msat"]
-						));
+						);
 					}
 
 					auto& av = available[peer];

--- a/Boss/Mod/ListfundsAnalyzer.cpp
+++ b/Boss/Mod/ListfundsAnalyzer.cpp
@@ -39,17 +39,19 @@ private:
 		ar.total_owned = Ln::Amount::msat(0);
 
 		for (auto output : l.outputs) {
-			auto amt_s = std::string(output["amount_msat"]);
-			if (!Ln::Amount::valid_string(amt_s))
+			auto amount_msat = output["amount_msat"];
+			if (!Ln::Amount::valid_object(amount_msat))
 				throw Jsmn::TypeError();
-			ar.total_owned += Ln::Amount(amt_s);
+			ar.total_owned +=
+				Ln::Amount::object(amount_msat);
 		}
 
 		for (auto channel : l.channels) {
-			auto amt_s = std::string(channel["our_amount_msat"]);
-			if (!Ln::Amount::valid_string(amt_s))
+			auto amount_msat = channel["our_amount_msat"];
+			if (!Ln::Amount::valid_object(amount_msat))
 				throw Jsmn::TypeError();
-			ar.total_owned += Ln::Amount(amt_s);
+			ar.total_owned +=
+				Ln::Amount::object(amount_msat);
 		}
 
 		return bus.raise(std::move(ar));

--- a/Boss/Mod/ListpaysHandler.cpp
+++ b/Boss/Mod/ListpaysHandler.cpp
@@ -63,12 +63,12 @@ Ev::Io<void> ListpaysHandler::listpays(Sha256::Hash h) {
 				resp.status = Msg::StatusListpays_pending;
 			} else if (status == "complete") {
 				resp.status = Msg::StatusListpays_success;
-				resp.amount = Ln::Amount(std::string(
+				resp.amount = Ln::Amount::object(
 					pay["amount_msat"]
-				));
-				resp.amount_sent = Ln::Amount(std::string(
+				);
+				resp.amount_sent = Ln::Amount::object(
 					pay["amount_sent_msat"]
-				));
+				);
 			} else throw Jsmn::TypeError();
 		} catch (Jsmn::TypeError const&) {
 			resp.status = Msg::StatusListpays_nonexistent;

--- a/Boss/Mod/MoveFundsCommand.cpp
+++ b/Boss/Mod/MoveFundsCommand.cpp
@@ -25,12 +25,13 @@ private:
 		bus.subscribe<Msg::Manifestation
 			     >([&bus](Msg::Manifestation const& _) {
 			return bus.raise(Msg::ManifestCommand{
+				/* NOTE - this documents the post v23.02 msat convention. */
 				"clboss-movefunds",
-				"amount sourcenode destnode feebudget",
-				"Move {amount} from a channel with "
+				"amount_msat sourcenode destnode feebudget_msat",
+				"Move {amount_msat} from a channel with "
 				"{sourcenode} to a channel with {destnode}, "
-				"with no more than {feebudget}.  "
-				"{amount} and {feebudget} must have 'msat' "
+				"with no more than {feebudget_msat}.  "
+				"{amount_msat} and {feebudget_msat} must not have 'msat' "
 				"suffixes, and {sourcenode} and {destnode} "
 				"must be node IDs.  "
 				"THIS COMMAND IS FOR DEBUGGING CLBOSS AND "
@@ -71,15 +72,15 @@ private:
 					dst = parms[2];
 					fee = parms[3];
 				} else {
-					amt = parms["amount"];
+					amt = parms["amount_msat"];
 					src = parms["sourcenode"];
 					dst = parms["destnode"];
-					fee = parms["feebudget"];
+					fee = parms["feebudget_msat"];
 				}
-				msg.amount = Ln::Amount(std::string(amt));
+				msg.amount = Ln::Amount::object(amt);
 				msg.source = Ln::NodeId(std::string(src));
 				msg.destination = Ln::NodeId(std::string(dst));
-				msg.fee_budget = Ln::Amount(std::string(fee));
+				msg.fee_budget = Ln::Amount::object(fee);
 			} catch (std::exception const& _) {
 				return bus.raise(Msg::CommandFail{
 					id, -32602, "Invalid parameters.",

--- a/Boss/Mod/NodeBalanceSwapper.cpp
+++ b/Boss/Mod/NodeBalanceSwapper.cpp
@@ -140,17 +140,17 @@ private:
 				   , Ln::Amount& recv
 				   , Jsmn::Object const& c
 				   ) {
-		auto to_us = Ln::Amount(std::string(c["to_us_msat"]));
-		auto total = Ln::Amount(std::string(c["total_msat"]));
+		auto to_us = Ln::Amount::object(c["to_us_msat"]);
+		auto total = Ln::Amount::object(c["total_msat"]);
 		auto their = total - to_us;
 		for (auto h : c["htlcs"])
-			their -= Ln::Amount(std::string(h["amount_msat"]));
-		auto our_reserve = Ln::Amount(std::string(
+			their -= Ln::Amount::object(h["amount_msat"]);
+		auto our_reserve = Ln::Amount::object(
 			c["our_reserve_msat"]
-		));
-		auto their_reserve = Ln::Amount(std::string(
+		);
+		auto their_reserve = Ln::Amount::object(
 			c["their_reserve_msat"]
-		));
+		);
 		send = to_us - our_reserve;
 		recv = their - their_reserve;
 	}

--- a/Boss/Mod/OnchainFundsAnnouncer.cpp
+++ b/Boss/Mod/OnchainFundsAnnouncer.cpp
@@ -77,21 +77,16 @@ Ev::Io<void> OnchainFundsAnnouncer::announce() {
 		if (!res.has("excess_msat"))
 			return fail("fundpsbt has no excess_msat", res);
 		auto excess_msat = res["excess_msat"];
-		if (!excess_msat.is_string())
-			return fail( "fundpsbt excess_msat not a string"
+		if (!Ln::Amount::valid_object(excess_msat))
+			return fail( "fundpsbt excess_msat not a valid amount"
 				   , excess_msat
 				   );
-		auto excess_msat_s = std::string(excess_msat);
-		if (!Ln::Amount::valid_string(excess_msat_s))
-			return fail( "fundpsbt excess_msat not valid amount"
-				   , excess_msat
-				   );
-		auto amount = Ln::Amount(excess_msat_s);
+		auto amount = Ln::Amount::object(excess_msat);
 
 		return Boss::log( bus, Debug
 				, "OnchainFundsAnnouncer: "
 				  "Found %s (after deducting fee to spend) onchain."
-				, excess_msat_s.c_str()
+				, std::string(amount).c_str()
 				).then([this, amount]() {
 			return bus.raise(Msg::OnchainFunds{amount});
 		});

--- a/Boss/Mod/PeerCompetitorFeeMonitor/Surveyor.cpp
+++ b/Boss/Mod/PeerCompetitorFeeMonitor/Surveyor.cpp
@@ -142,9 +142,9 @@ std::string Surveyor::one_channel(Jsmn::Object const& c) {
 		auto proportional = std::uint32_t(double(
 			c["fee_per_millionth"]
 		));
-		auto weight = Ln::Amount(std::string(
+		auto weight = Ln::Amount::object(
 			c["amount_msat"]
-		));
+		);
 		bases.add(base, weight);
 		proportionals.add(proportional, weight);
 	} catch (Jsmn::TypeError const&) {

--- a/Boss/Mod/PeerJudge/DataGatherer.cpp
+++ b/Boss/Mod/PeerJudge/DataGatherer.cpp
@@ -80,9 +80,9 @@ private:
 						);
 						if (state != "CHANNELD_NORMAL")
 							continue;
-						total += Ln::Amount(std::string(
+						total += Ln::Amount::object(
 							c["total_msat"]
-						));
+						);
 					}
 
 					/* No active channels?  Skip.  */

--- a/Boss/Mod/SwapManager.cpp
+++ b/Boss/Mod/SwapManager.cpp
@@ -736,9 +736,8 @@ private:
 			for (auto out : outputs)
 				onchain_funds.push(std::make_pair(
 					std::string(out["address"]),
-					Ln::Amount(std::string(
-						out["amount_msat"]
-					))
+					Ln::Amount::object(out["amount_msat"]
+					)
 				));
 
 			if (was_empty)

--- a/Ln/Amount.cpp
+++ b/Ln/Amount.cpp
@@ -28,6 +28,25 @@ bool Amount::valid_string(std::string const& s) {
 	return true;
 }
 
+bool Amount::valid_object(Jsmn::Object const& o) {
+	if (o.is_number())
+		return true;
+	else if (o.is_string())
+		return valid_string(std::string(o));
+	else
+		return false;
+}
+
+Amount
+Amount::object(Jsmn::Object const& o) {
+	if (o.is_number())
+		return Amount::msat(std::uint64_t(double(o)));
+	else if (o.is_string())
+		return Amount(std::string(o));
+	else
+		throw std::invalid_argument("Ln::Amount json object invalid.");
+}
+
 Amount::Amount(std::string const& s) {
 	if (!valid_string(s))
 		throw std::invalid_argument("Ln::Amount string invalid.");

--- a/Ln/Amount.hpp
+++ b/Ln/Amount.hpp
@@ -1,6 +1,7 @@
 #ifndef LN_AMOUNT_HPP
 #define LN_AMOUNT_HPP
 
+#include"Jsmn/Object.hpp"
 #include<cstdint>
 #include<iostream>
 #include<string>
@@ -30,6 +31,13 @@ public:
 	 * string.  */
 	static
 	bool valid_string(std::string const&);
+
+	static
+	Amount object(Jsmn::Object const&);
+	/* Return false if Amount() would throw given this
+	 * object. */
+	static
+	bool valid_object(Jsmn::Object const&);
 
 	static
 	Amount btc(double v) {


### PR DESCRIPTION
The JSON-RPC interface has changed the type of amounts from string w/ "msat" suffix to a plain number.

The backtrace hack and removal of the Amount constructor-from-string are useful during debugging but we might want to drop them ...