### PR TITLE
Add exception backtraces

### DIFF
--- a/Jsmn/Object.cpp
+++ b/Jsmn/Object.cpp
@@ -8,7 +8,32 @@
 #include"Jsmn/Parser.hpp"
 #include"Util/Str.hpp"
 
+#include <cstdio>
+#include <execinfo.h>
+#include <cstdlib>
+#include <cxxabi.h>
+
 namespace Jsmn {
+
+void print_backtrace() {
+    constexpr size_t max_frames = 100;
+    void* addrlist[max_frames];
+
+    int stack_depth = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
+
+    if (stack_depth == 0) {
+      	std::fprintf(stderr, "No backtrace available.\n");
+        return;
+    }
+
+    char** symbollist = backtrace_symbols(addrlist, stack_depth);
+
+    for (int i = 0; i < stack_depth; i++) {
+	std::fprintf(stderr, "%s\n", symbollist[i]);
+    }
+
+    free(symbollist);
+}
 
 class Object::Impl {
 private:

--- a/Jsmn/Object.hpp
+++ b/Jsmn/Object.hpp
@@ -15,11 +15,15 @@ namespace Jsmn { class ParserExposedBuffer; }
 
 namespace Jsmn {
 
+void print_backtrace();
+
 /* Thrown when converting or using as incorrect type.  */
 /* FIXME: Use a backtrace-catching exception.  */
 class TypeError : public std::invalid_argument {
 public:
-	TypeError() : std::invalid_argument("Incorrect type.") { }
+	TypeError() : std::invalid_argument("Incorrect type.") {
+		print_backtrace();
+        }
 };
 
 /* Represents an object that has been parsed from a JSON string.  */


### PR DESCRIPTION
TODO:
- [ ] Store minimum unresolved backtrace in exception, print later in the unhandled handler
- [ ] Move backtrace code to common location for all exceptions, add to all appropriate exceptions
- [ ] Improve output w/ source lines and demangled symbols