### PR TITLE
Fix rpc error: blockheight: should be an integer

### DIFF
--- a/Boss/Mod/BlockTracker.cpp
+++ b/Boss/Mod/BlockTracker.cpp
@@ -26,7 +26,7 @@ Ev::Io<void> BlockTracker::loop(Boss::Mod::Rpc& rpc) {
 	return Ev::yield().then([this, &rpc]() {
 		auto js = Json::Out()
 			.start_object()
-				.field("blockheight", double(height + 1))
+				.field("blockheight", std::uint32_t(height + 1))
 				.field("timeout", double(86400))
 			.end_object()
 			;


### PR DESCRIPTION
Fix required when the number of blocks is large enough to trigger a floating represention, then it fails to parse