### PR TITLE
build: Use `__GNUC__` instead of `__GNUC_PREREQ`, fixes Alpine build

### DIFF
--- a/Util/Compiler.hpp
+++ b/Util/Compiler.hpp
@@ -1,14 +1,10 @@
 #ifndef COMPILER_H_
 #define COMPILER_H_
 
-#ifdef __GNUC__
-#include <features.h>
+#if defined(__GNUC__) && (__GNUC__ >= 13)
 // We need a GCC patch here due the following bug
 // <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107134>
-#if __GNUC_PREREQ(13,0)
 #include<cstdint>
 #endif
-#endif
-
 
 #endif // COMPILER_H_


### PR DESCRIPTION
Changelog-Fixed: build: Use `__GNUC__` instead of `__GNUC_PREREQ`, fixes Alpine build ([#178])