### PR TITLE
Add autoconf buildInput to nix flake and clean up formatting a bit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
         formatter = pkgs.nixpkgs-fmt;
         devShell = pkgs.mkShell {
-          buildInputs = [ pkgs.gcc pkgs.pkg-config pkgs.libev pkgs.libevdev pkgs.curl pkgs.sqlite pkgs.bind pkgs.autoconf-archive pkgs.libtool pkgs.automake pkgs.git ];
+          buildInputs = with pkgs; [ gcc pkg-config libev libevdev curl sqlite bind autoconf autoconf-archive libtool automake git ];
         };
       }
     );


### PR DESCRIPTION
This fixes the build error I was getting:

```
❯ autoreconf -i
The program 'autoreconf' is currently not installed. It is provided by
several packages. You can install it by typing one of the following:
  nix-env -iA nixpkgs.autoconf264.out
  nix-env -iA nixpkgs.autoconf.out
  nix-env -iA nixpkgs.autoconf269.out
  nix-env -iA nixpkgs.autoconf213.out

Or run it once with:
  nix-shell -p autoconf264.out --run ...
  nix-shell -p autoconf.out --run ...
  nix-shell -p autoconf269.out --run ...
  nix-shell -p autoconf213.out --run ...
```

Now you can just do:

```
nix develop
autoreconf -i
./configure && make
```

and the build succeeds