### PR TITLE
Release v0.13.1

### DIFF
--- a/Boss/Mod/EarningsRebalancer.cpp
+++ b/Boss/Mod/EarningsRebalancer.cpp
@@ -157,11 +157,6 @@ private:
 				));
 
 				for (auto c : p["channels"]) {
-					auto priv = bool(
-						c["private"]
-					);
-					if (priv)
-						continue;
 					auto state = std::string(
 						c["state"]
 					);

--- a/Boss/Mod/InitialRebalancer.cpp
+++ b/Boss/Mod/InitialRebalancer.cpp
@@ -182,11 +182,6 @@ private:
 
 					auto cs = p["channels"];
 					for (auto c : cs) {
-						auto priv = bool(
-							c["private"]
-						);
-						if (priv)
-							continue;
 						auto state = std::string(
 							c["state"]
 						);

--- a/Boss/Mod/NodeBalanceSwapper.cpp
+++ b/Boss/Mod/NodeBalanceSwapper.cpp
@@ -57,12 +57,6 @@ private:
 						  != "CHANNELD_NORMAL"
 						   )
 							continue;
-						/* Skip unpublished channels,
-						 * they cannot be used for
-						 * forwarding anyway.
-						 */
-						if (chan["private"])
-							continue;
 						auto recv = Ln::Amount();
 						auto send = Ln::Amount();
 						compute_sendable_receivable(

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.13.1] - 2024-04-16: "E Street Fix"
+
+### Fixed
+
+- CLN `v24.02` deprecated the RPC `msatoshi` fields which needed to be
+  converted to `amount_msat` instead.  This caused channel candidates
+  to not be found ([#189]) (and maybe other problems).  Fixed in
+  ([#190]).
+
+### Changed
+
+- The minimum number of network nodes seen before initiating certain
+  actions is 800 in the bitcoin network.  ([#173]) changes this
+  threshold for the testnet (300) and other networks (10).  The new
+  thresholds should allow CLBOSS to act when there are fewer available
+  nodes.  The bitcoin limit remains 800.
+
 ## [0.13] - 2023-09-08: "Born to Run"
 
 ### Added

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   converted to `amount_msat` instead.  This caused channel candidates
   to not be found ([#189]) (and maybe other problems).  Fixed in
   ([#190]).
+- CLN `v24.02` deprecated the RPC `private` field in the channel info
+  RPC data because private channels are no longer present.  Remove
+  references to the field because we only want to skip these channels
+  anyway.  Fixes ([192])
 
 ### Changed
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([clboss], [0.13], [ZmnSCPxj@protonmail.com])
+AC_INIT([clboss], [0.13.1], [ken@bonsai.com])
 AC_CONFIG_AUX_DIR([auxdir])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar])
 AC_CONFIG_SRCDIR([main.cpp])

--- a/tests/boss/test_earningsrebalancer.cpp
+++ b/tests/boss/test_earningsrebalancer.cpp
@@ -74,7 +74,6 @@ public:
 					.field("id", std::string(p.first))
 					.start_array("channels")
 						.start_object()
-							.field("private", false)
 							.field("state", "CHANNELD_NORMAL")
 							.field("to_us_msat", std::string(p.second.to_us))
 							.field("total_msat", std::string(p.second.total))

--- a/tests/boss/test_initialrebalancer.cpp
+++ b/tests/boss/test_initialrebalancer.cpp
@@ -53,8 +53,7 @@ public:
  */
 auto const peers = std::string(R"JSON(
 [ { "id" : "020000000000000000000000000000000000000000000000000000000000000000"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "1000000000msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []
@@ -62,8 +61,7 @@ auto const peers = std::string(R"JSON(
                  ]
   }
 , { "id" : "020000000000000000000000000000000000000000000000000000000000000001"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "0msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []
@@ -73,8 +71,7 @@ auto const peers = std::string(R"JSON(
 
 
 , { "id" : "020000000000000000000000000000000000000000000000000000000000000003"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "0msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []
@@ -82,8 +79,7 @@ auto const peers = std::string(R"JSON(
                  ]
   }
 , { "id" : "020000000000000000000000000000000000000000000000000000000000000004"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "1000000000msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []


### PR DESCRIPTION
Checklist:
- [x] `v0.13.1rc1`
- [x] decide on no-private
- [x] stable