### PR TITLE
remove references to the "private" field of channel info returned from listpeers RPC

### DIFF
--- a/Boss/Mod/EarningsRebalancer.cpp
+++ b/Boss/Mod/EarningsRebalancer.cpp
@@ -157,11 +157,6 @@ private:
 				));
 
 				for (auto c : p["channels"]) {
-					auto priv = bool(
-						c["private"]
-					);
-					if (priv)
-						continue;
 					auto state = std::string(
 						c["state"]
 					);

--- a/Boss/Mod/InitialRebalancer.cpp
+++ b/Boss/Mod/InitialRebalancer.cpp
@@ -182,11 +182,6 @@ private:
 
 					auto cs = p["channels"];
 					for (auto c : cs) {
-						auto priv = bool(
-							c["private"]
-						);
-						if (priv)
-							continue;
 						auto state = std::string(
 							c["state"]
 						);

--- a/Boss/Mod/NodeBalanceSwapper.cpp
+++ b/Boss/Mod/NodeBalanceSwapper.cpp
@@ -57,12 +57,6 @@ private:
 						  != "CHANNELD_NORMAL"
 						   )
 							continue;
-						/* Skip unpublished channels,
-						 * they cannot be used for
-						 * forwarding anyway.
-						 */
-						if (chan["private"])
-							continue;
 						auto recv = Ln::Amount();
 						auto send = Ln::Amount();
 						compute_sendable_receivable(

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   converted to `amount_msat` instead.  This caused channel candidates
   to not be found ([#189]) (and maybe other problems).  Fixed in
   ([#190]).
+- CLN `v24.02` deprecated the RPC `private` field in the channel info
+  RPC data because private channels are no longer present.  Remove
+  references to the field because we only want to skip these channels
+  anyway.  Fixes ([192])
 
 ### Changed
 

--- a/tests/boss/test_earningsrebalancer.cpp
+++ b/tests/boss/test_earningsrebalancer.cpp
@@ -74,7 +74,6 @@ public:
 					.field("id", std::string(p.first))
 					.start_array("channels")
 						.start_object()
-							.field("private", false)
 							.field("state", "CHANNELD_NORMAL")
 							.field("to_us_msat", std::string(p.second.to_us))
 							.field("total_msat", std::string(p.second.total))

--- a/tests/boss/test_initialrebalancer.cpp
+++ b/tests/boss/test_initialrebalancer.cpp
@@ -53,8 +53,7 @@ public:
  */
 auto const peers = std::string(R"JSON(
 [ { "id" : "020000000000000000000000000000000000000000000000000000000000000000"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "1000000000msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []
@@ -62,8 +61,7 @@ auto const peers = std::string(R"JSON(
                  ]
   }
 , { "id" : "020000000000000000000000000000000000000000000000000000000000000001"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "0msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []
@@ -73,8 +71,7 @@ auto const peers = std::string(R"JSON(
 
 
 , { "id" : "020000000000000000000000000000000000000000000000000000000000000003"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "0msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []
@@ -82,8 +79,7 @@ auto const peers = std::string(R"JSON(
                  ]
   }
 , { "id" : "020000000000000000000000000000000000000000000000000000000000000004"
-  , "channels" : [ { "private" : false
-                   , "state" : "CHANNELD_NORMAL"
+  , "channels" : [ { "state" : "CHANNELD_NORMAL"
                    , "to_us_msat" : "1000000000msat"
                    , "total_msat" : "1000000000msat"
                    , "htlcs" : []


### PR DESCRIPTION
Maybe fixes https://github.com/ZmnSCPxj/clboss/issues/192

The private field has been removed because the private channels are no longer supposed to show up in the list:
https://github.com/ElementsProject/lightning/commit/37ccca5d69c38adbbbceb81e2e18b9699b6cd53c

Since we were always checking private to skip the channel it seems safe to simply not check for it anymore ...