### PR TITLE
add signet

### DIFF
--- a/Boss/Mod/Initiator.cpp
+++ b/Boss/Mod/Initiator.cpp
@@ -189,6 +189,8 @@ public:
 				network = Boss::Msg::Network_Bitcoin;
 			else if (network_s == "testnet")
 				network = Boss::Msg::Network_Testnet;
+			else if (network_s == "signet")
+				network = Boss::Msg::Network_Signet;
 			else if (network_s == "regtest")
 				network = Boss::Msg::Network_Regtest;
 			else

--- a/Boss/Msg/Network.hpp
+++ b/Boss/Msg/Network.hpp
@@ -6,6 +6,7 @@ namespace Boss { namespace Msg {
 enum Network
 { Network_Bitcoin
 , Network_Testnet
+, Network_Signet
 , Network_Regtest
 };
 


### PR DESCRIPTION
Add support for networks named `signet`. Tested only with mutinynet so far. Seems to be opening channels just fine, but obviously swaps won't work until Boltz supports mutinynet/signet swaps (or we add a swapping method other than Boltz).

Closes #148 