### PR TITLE
testnet: reduce the min_nodes_to_process because testnet is shrinking

### DIFF
--- a/Boss/Mod/ChannelFinderByPopularity.cpp
+++ b/Boss/Mod/ChannelFinderByPopularity.cpp
@@ -136,7 +136,7 @@ private:
 			db = init.db;
 			switch (init.network) {
 			case Boss::Msg::Network_Bitcoin: min_nodes_to_process = 800; break;
-			case Boss::Msg::Network_Testnet: min_nodes_to_process = 300; break;
+			case Boss::Msg::Network_Testnet: min_nodes_to_process = 200; break;
 			default: min_nodes_to_process = 10; break; // others are likely small
 			}
 			return db.transact().then([this](Sqlite3::Tx tx) {


### PR DESCRIPTION
Changelog-Changed: testnet: The minimum number of nodes (with channels) before the ChannelFinderByPopularity starts is reduced from 300 to 200.