### PR TITLE
Recognize `--developer` CLI flag and don't exit giving usage ([#185])

### DIFF
--- a/Boss/Main.cpp
+++ b/Boss/Main.cpp
@@ -74,8 +74,16 @@ public:
 				if (system(os.str().c_str()))
 					;
 				kill(getpid(), SIGSTOP);
-			} else
+			} else if (argv1 == "--developer") {
+				/* In the future we might want to do something, but for now
+				 * accept and don't fail with usage message
+				 */
+			} else {
+				std::cerr << argv0 << ":"
+					  << " Unrecognized option: " << argv1
+					  << std::endl;
 				is_help = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
CLBOSS did not know the `--developer` flag and generated a usage message and exited.  Fixed with:
- recognize and consume the `developer` flag, no actions for now
- print unrecognized options to std::cerr

Fixes ([#185])