### PR TITLE
Improve the logged version string and add clboss-status "info"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ auxdir
 test_*
 !test_*.cpp
 !test_*.c
+/commit_hash.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -566,7 +566,9 @@ EXTRA_DIST = \
 	reproducible/README.md \
 	reproducible/build.sh \
 	reproducible/continue.sh \
-	reproducible/manifest.scm.template 
+	reproducible/manifest.scm.template \
+    generate_commit_hash.sh \
+    commit_hash.h
 
 AM_CXXFLAGS = -Wall -Werror $(PTHREAD_CFLAGS) $(libev_CFLAGS) $(SQLITE3_CFLAGS) $(CURL_CFLAGS) $(CLBOSS_CXXFLAGS)
 LDADD = libclboss.la $(PTHREAD_LIBS) $(libev_LIBS) $(SQLITE3_LIBS) $(CURL_LIBS)
@@ -668,3 +670,11 @@ CLEANFILES = $(noinst_SCRIPTS)
 create-tarball: create-tarball.in Makefile
 	sed -e 's/[@]PACKAGE_VERSION[@]/$(PACKAGE_VERSION)/' < $(srcdir)/create-tarball.in > create-tarball
 	chmod +x create-tarball
+
+BUILT_SOURCES = commit_hash.h
+CLEANFILES += commit_hash.h
+
+commit_hash.h:
+	./generate_commit_hash.sh
+
+clboss libclboss.la: $(BUILT_SOURCES)

--- a/generate_commit_hash.sh
+++ b/generate_commit_hash.sh
@@ -1,0 +1,4 @@
+# generate_commit_hash.sh
+echo "#pragma once" > commit_hash.h
+echo "#define GIT_COMMIT_HASH \"$(git rev-parse HEAD)\"" >> commit_hash.h
+echo "#define GIT_DESCRIBE \"$(git describe --tags --long --always --match=v*.* --dirty)\"" >> commit_hash.h


### PR DESCRIPTION
The logged version now looks like:
plugin-clboss: clboss v0.13.2 (v0.13.2-rc1-3-g44832e2)

A new "info" chunk is added to clboss-status:
   "info": {
      "version": "v0.13.2",
      "git_commit_hash": "44832e2258069641a6149bdc90b7e5fc12219f77",
      "git_describe": "v0.13.2-rc1-3-g44832e2"
   },

Fixes #205