### PR TITLE
Add Util::BacktraceException wrapper

### DIFF
--- a/Bitcoin/Tx.cpp
+++ b/Bitcoin/Tx.cpp
@@ -88,9 +88,9 @@ Tx::Tx(std::string const& s) {
 	auto is = std::istringstream(std::move(str));
 	is >> *this;
 	if (!is.good())
-		throw std::invalid_argument("Bitcoin::Tx: invalid hex string input.");
+		throw Util::BacktraceException<std::invalid_argument>("Bitcoin::Tx: invalid hex string input.");
 	if (is.get() != std::char_traits<char>::eof())
-		throw std::invalid_argument("Bitcoin::Tx: input string too long.");
+		throw Util::BacktraceException<std::invalid_argument>("Bitcoin::Tx: input string too long.");
 }
 
 Bitcoin::TxId Tx::get_txid() const {

--- a/Bitcoin/addr_to_scriptPubKey.hpp
+++ b/Bitcoin/addr_to_scriptPubKey.hpp
@@ -1,6 +1,7 @@
 #ifndef BITCOIN_ADDR_TO_SCRIPTPUBKEY_HPP
 #define BITCOIN_ADDR_TO_SCRIPTPUBKEY_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<cstdint>
 #include<string>
 #include<stdexcept>
@@ -8,10 +9,10 @@
 
 namespace Bitcoin {
 
-struct UnknownAddrType : public std::invalid_argument {
+struct UnknownAddrType : public Util::BacktraceException<std::invalid_argument> {
 public:
 	UnknownAddrType()
-		: std::invalid_argument("Bitcoin::UnknownAddrType") { }
+		: Util::BacktraceException<std::invalid_argument>("Bitcoin::UnknownAddrType") { }
 };
 
 /** Bitcoin::addr_to_scriptPubKey

--- a/Bitcoin/sighash.hpp
+++ b/Bitcoin/sighash.hpp
@@ -19,10 +19,10 @@ enum SighashFlags
 , SIGHASH_ANYONECANPAY = 0x80
 };
 
-struct InvalidSighash : public std::invalid_argument {
+struct InvalidSighash : public Util::BacktraceException<std::invalid_argument> {
 	InvalidSighash() =delete;
 	InvalidSighash(std::string const& msg)
-		: std::invalid_argument(
+		: Util::BacktraceException<std::invalid_argument>(
 			std::string("Bitcoin::InvalidSighash: ") + msg
 		  ) { }
 };

--- a/Boltz/ConnectionIF.hpp
+++ b/Boltz/ConnectionIF.hpp
@@ -1,6 +1,7 @@
 #ifndef BOLTZ_CONNECTIONIF_HPP
 #define BOLTZ_CONNECTIONIF_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<memory>
 #include<stdexcept>
 #include<string>
@@ -35,10 +36,10 @@ public:
  * @brief thrown when communications with
  * the BOLTZ server has problems.
  */
-class ApiError : public std::runtime_error {
+class ApiError : public Util::BacktraceException<std::runtime_error> {
 public:
 	ApiError(std::string const& e
-		) : std::runtime_error(e) { }
+		) : Util::BacktraceException<std::runtime_error>(e) { }
 };
 
 }

--- a/Boss/Mod/ChannelCreateDestroyMonitor.cpp
+++ b/Boss/Mod/ChannelCreateDestroyMonitor.cpp
@@ -149,12 +149,13 @@ void ChannelCreateDestroyMonitor::start() {
 		try {
 			auto payload = params["channel_opened"];
 			n = Ln::NodeId(std::string(payload["id"]));
-		} catch (std::runtime_error const&) {
+		} catch (std::runtime_error const& err) {
 			return Boss::log( bus, Error
 					, "ChannelCreateDestroyMonitor: "
 					  "Unexpected channel_opened "
-					  "payload: %s"
+					  "payload: %s: %s"
 					, Util::stringify(params).c_str()
+					, err.what()
 					);
 		}
 		/* Is it already in channeled?  */
@@ -174,12 +175,13 @@ void ChannelCreateDestroyMonitor::start() {
 			n = Ln::NodeId(std::string(payload["peer_id"]));
 			old_state = std::string(payload["old_state"]);
 			new_state = std::string(payload["new_state"]);
-		} catch (std::runtime_error const&) {
+		} catch (std::runtime_error const& err) {
 			return Boss::log( bus, Error
 					, "ChannelCreateDestroyMonitor: "
 					  "Unexpected channel_state_changed "
-					  "payload: %s"
+					  "payload: %s: %s"
 					, Util::stringify(params).c_str()
+					, err.what()
 					);
 		}
 		/* Only continue if we are leaving the CHANNELD_NORMAL

--- a/Boss/Mod/ChannelCreator/Carpenter.cpp
+++ b/Boss/Mod/ChannelCreator/Carpenter.cpp
@@ -157,14 +157,15 @@ Carpenter::construct(std::map<Ln::NodeId, Ln::Amount> plan) {
 					report << ", ";
 				report << node;
 			}
-		} catch (std::invalid_argument const&) {
+		} catch (std::invalid_argument const& ex) {
 			auto os = std::ostringstream();
 			os << res;
 			return Boss::log( bus, Error
 					, "ChannelCreator::Carpenter: "
 					  "Unexpected result from "
-					  "multifundchannel: %s"
+					  "multifundchannel: %s: %s"
 					, os.str().c_str()
+					, ex.what()
 					);
 		}
 

--- a/Boss/Mod/ChannelFinderByEarnedFee.cpp
+++ b/Boss/Mod/ChannelFinderByEarnedFee.cpp
@@ -131,12 +131,13 @@ private:
 						continue;
 					props.emplace(std::move(dest));
 				}
-			} catch (std::exception const&) {
+			} catch (std::exception const& ex) {
 				return Boss::log( bus, Error
 						, "ChannelFinderByEarnedFees: "
 						  "Unexpected result from "
-						  "`listchannels`: %s"
+						  "`listchannels`: %s: %s"
 						, Util::stringify(res).c_str()
+						, ex.what()
 						);
 			}
 			res = Jsmn::Object();

--- a/Boss/Mod/ChannelFinderByListpays.cpp
+++ b/Boss/Mod/ChannelFinderByListpays.cpp
@@ -159,12 +159,13 @@ Ev::Io<void> ChannelFinderByListpays::extract_payees_loop() {
 				++pit->second;
 			++count;
 			return extract_payees_loop();
-		} catch (std::exception const&) {
+		} catch (std::exception const& ex) {
 			return Boss::log( bus, Error
 					, "ChannelFinderByListpays: "
 					  "Unexpected result from `listpays` "
-					  "`pays` field: %s"
+					  "`pays` field: %s: %s"
 					, Util::stringify(pay).c_str()
+					, ex.what()
 					);
 		}
 	});

--- a/Boss/Mod/FeeModderByBalance.cpp
+++ b/Boss/Mod/FeeModderByBalance.cpp
@@ -186,14 +186,14 @@ private:
 					);
 					break;
 				}
-			} catch (std::exception const&) {
+			} catch (std::exception const& ex) {
 				found = false;
 				act = Boss::log( bus, Error
 					       , "FeeModderByBalance: "
 						 "Unexpected result from "
-						 "listpeerchannels: %s"
-					       , Util::stringify(res)
-							.c_str()
+						 "listpeerchannels: %s: %s"
+					       , Util::stringify(res).c_str()
+					       , ex.what()
 					       );
 			}
 			typedef ChannelSpecs CS;

--- a/Boss/Mod/FeeModderBySize.cpp
+++ b/Boss/Mod/FeeModderBySize.cpp
@@ -384,14 +384,14 @@ private:
 						continue;
 					rv.insert(n);
 				}
-			} catch (std::exception const&) {
+			} catch (std::exception const& ex) {
 				return Boss::log( bus, Error
 						, "FeeModderBySize: "
 						  "get_competitors: "
 						  "Unexpected result from "
-						  "listchannels: %s"
-						, Util::stringify(res)
-							.c_str()
+						  "listchannels: %s: %s"
+						, Util::stringify(res).c_str()
+						, ex.what()
 						).then([rv]() {
 					return Ev::lift(rv);
 				});

--- a/Boss/Mod/ForwardFeeMonitor.cpp
+++ b/Boss/Mod/ForwardFeeMonitor.cpp
@@ -50,11 +50,12 @@ void ForwardFeeMonitor::start() {
 					- double(payload["received_time"])
 					;
 
-		} catch (std::runtime_error const& _) {
+		} catch (std::runtime_error const& err) {
 			return Boss::log( bus, Error
 					, "ForwardFeeMonitor: Unexpected "
-					  "forward_event payload: %s"
+					  "forward_event payload: %s: %s"
 					, Util::stringify(n.params).c_str()
+					, err.what()
 					);
 		}
 

--- a/Boss/Mod/FundsMover/Attempter.cpp
+++ b/Boss/Mod/FundsMover/Attempter.cpp
@@ -348,15 +348,15 @@ private:
 						data["failcode"]
 					));
 				}
-			} catch (std::exception const&) {
+			} catch (std::exception const& ex) {
 				return std::move(act)
 				     + Boss::log( bus, Error
 						, "FundsMover: Attempt: "
 						  "Unexpected error from "
-						  "%s: %s"
+						  "%s: %s: %s"
 						, e.command.c_str()
-						, Util::stringify(e.error)
-							.c_str()
+						, Util::stringify(e.error).c_str()
+						, ex.what()
 						);
 			}
 

--- a/Boss/Mod/FundsMover/Runner.cpp
+++ b/Boss/Mod/FundsMover/Runner.cpp
@@ -94,11 +94,12 @@ Ev::Io<void> Runner::gather_info() {
 				));
 				break;
 			}
-		} catch (std::exception const&) {
+		} catch (std::exception const& ex) {
 			return Boss::log( bus, Error
 					, "FundsMover: Unexpected result "
-					  "from listchannels: %s"
+					  "from listchannels: %s: %s"
 					, Util::stringify(res).c_str()
+					, ex.what()
 					);
 		}
 		return Ev::lift();
@@ -134,11 +135,12 @@ Ev::Io<void> Runner::gather_info() {
 				));
 				break;
 			}
-		} catch (std::exception const&) {
+		} catch (std::exception const& ex) {
 			return Boss::log( bus, Error
 					, "FundsMover: Unexpected result "
-					  "from listchannels: %s"
+					  "from listchannels: %s: %s"
 					, Util::stringify(res).c_str()
+					, ex.what()
 					);
 		}
 		return Ev::lift();

--- a/Boss/Mod/Initiator.cpp
+++ b/Boss/Mod/Initiator.cpp
@@ -104,7 +104,7 @@ private:
 				, meth
 				, is.c_str()
 				).then([]() {
-			throw std::runtime_error("Unexpected result.");
+			throw Util::BacktraceException<std::runtime_error>("Unexpected result.");
 			return Ev::lift();
 		});
 	}

--- a/Boss/Mod/JitRebalancer.cpp
+++ b/Boss/Mod/JitRebalancer.cpp
@@ -337,11 +337,12 @@ private:
 					av.to_us += to_us;
 					av.capacity += capacity;
                                 }
-			} catch (std::exception const&) {
+			} catch (std::exception const& ex) {
 				return Boss::log( bus, Error
 						, "JitRebalancer: Unexpected "
-						  "result from listpeerchannels: %s"
+						  "result from listpeerchannels: %s: %s"
 						, Util::stringify(res).c_str()
+						, ex.what()
 						).then([]() {
 					throw Continue();
 					return Ev::lift();

--- a/Boss/Mod/PaymentDeleter.cpp
+++ b/Boss/Mod/PaymentDeleter.cpp
@@ -108,12 +108,12 @@ private:
 			try {
 				pays = res["pays"];
 				it = pays.begin();
-			} catch (std::exception const&) {
+			} catch (std::exception const& ex) {
 				return Boss::log( bus, Error
 						, "PaymentDeleter: Unexpected "
-						  "result from 'listpays': "
-						  "%s"
+						  "result from 'listpays': %s: %s"
 						, Util::stringify(res).c_str()
+						, ex.what()
 						);
 			}
 			return loop();
@@ -156,13 +156,13 @@ private:
 				     + delpay(payment_hash, status)
 				     + loop()
 				     ;
-			} catch (std::exception const&) {
+			} catch (std::exception const& ex) {
 				return Boss::log( bus, Error
 						, "PaymentDeleter: "
 						  "Unexpected 'pays' entry "
-						  "from 'listpays': %s"
-						, Util::stringify(pay)
-							.c_str()
+						  "from 'listpays': %s: %s"
+						, Util::stringify(pay).c_str()
+						, ex.what()
 						);
 			}
 		});

--- a/Boss/Mod/PeerJudge/DataGatherer.cpp
+++ b/Boss/Mod/PeerJudge/DataGatherer.cpp
@@ -90,13 +90,13 @@ private:
 						id, total
 					});
 				}
-			} catch (std::exception const& e) {
+			} catch (std::exception const& ex) {
 				infos->clear();
 				return Boss::log( bus, Error
 						, "PeerJudge: Unexpected "
-						  "listpeers result: %s"
-						, Util::stringify(peers)
-							.c_str()
+						  "listpeers result: %s: %s"
+						, Util::stringify(peers).c_str()
+						, ex.what()
 						);
 			}
 			return Ev::lift();

--- a/Boss/Mod/Rpc.cpp
+++ b/Boss/Mod/Rpc.cpp
@@ -60,7 +60,7 @@ std::string RpcError::make_error_message( std::string const& command
 
 RpcError::RpcError( std::string command_
 		  , Jsmn::Object error_
-		  ) : std::runtime_error(make_error_message(command_, error_))
+	          ) : Util::BacktraceException<std::runtime_error>(make_error_message(command_, error_))
 		    , command(command_)
 		    , error(error_)
 		    { }
@@ -200,13 +200,13 @@ private:
 					return std::size_t(0);
 				}
 				if (res < 0)
-					throw std::runtime_error(
+					throw Util::BacktraceException<std::runtime_error>(
 						std::string("Rpc: read: ") +
 						strerror(errno)
 					);
 				if (res == 0)
 					/* Unexpected end of file!  */
-					throw std::runtime_error(
+					throw Util::BacktraceException<std::runtime_error>(
 						"Rpc: read: unexpected end-of-file "
 						"in RPC socket."
 					);
@@ -263,7 +263,7 @@ private:
 				       ))
 				break;
 			if (res < 0)
-				throw std::runtime_error(
+				throw Util::BacktraceException<std::runtime_error>(
 					std::string("Rpc: write: ") +
 					strerror(errno)
 				);

--- a/Boss/Mod/Rpc.hpp
+++ b/Boss/Mod/Rpc.hpp
@@ -13,7 +13,7 @@ namespace S { class Bus; }
 
 namespace Boss { namespace Mod {
 
-struct RpcError : public std::runtime_error {
+struct RpcError : public Util::BacktraceException<std::runtime_error> {
 private:
 	static
 	std::string make_error_message( std::string const&

--- a/Boss/Mod/UnmanagedManager.cpp
+++ b/Boss/Mod/UnmanagedManager.cpp
@@ -272,7 +272,7 @@ private:
 		for (auto const& tag : tags) {
 			auto it = tag_informs.find(tag);
 			if (it == tag_informs.end())
-				throw std::runtime_error(
+				throw Util::BacktraceException<std::runtime_error>(
 					std::string("Unknown tag: ") + tag
 				);
 		}

--- a/Boss/Signer.cpp
+++ b/Boss/Signer.cpp
@@ -77,7 +77,7 @@ void try_create_privkey_file( std::string const& privkey_filename
 		/* Benign failure, file already exists.  */
 		return;
 	if (!fd)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Boss::Signer: creat(\"") +
 			privkey_filename +
 			"\"): " + strerror(errno)
@@ -88,7 +88,7 @@ void try_create_privkey_file( std::string const& privkey_filename
 	auto res = Util::Rw::write_all(fd.get(), &sk, sizeof(sk));
 	if (!res) {
 		unlink_noerr(privkey_filename);
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Boss::Signer: write(\"") +
 			privkey_filename +
 			"\"): " + strerror(errno)
@@ -101,7 +101,7 @@ Secp256k1::PrivKey
 read_privkey_file(std::string const& privkey_filename) {
 	auto fd = Net::Fd(open(privkey_filename.c_str(), O_RDONLY));
 	if (!fd)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Boss::Signer: open(\"") +
 			privkey_filename +
 			"\"): " + strerror(errno)
@@ -111,13 +111,13 @@ read_privkey_file(std::string const& privkey_filename) {
 	auto size = sizeof(sk);
 	auto res = Util::Rw::read_all(fd.get(), &sk, size);
 	if (!res)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Boss::Signer: read(\"") +
 			privkey_filename +
 			"\"): " + strerror(errno)
 		);
 	if (size != sizeof(sk))
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Boss::Signer: read(\"") +
 			privkey_filename +
 			"\"): unexpected end-of-file"
@@ -196,7 +196,7 @@ public:
 				/* Check it matches.  */
 				auto actual_pk = Secp256k1::PubKey(self->sk);
 				if (actual_pk != pubkey)
-					throw std::runtime_error(
+					throw Util::BacktraceException<std::runtime_error>(
 						std::string("Boss::Signer: ") +
 						self->privkey_filename +
 						": not matched to database!"

--- a/Boss/open_rpc_socket.cpp
+++ b/Boss/open_rpc_socket.cpp
@@ -1,5 +1,6 @@
 #include"Boss/open_rpc_socket.hpp"
 #include"Net/Fd.hpp"
+#include"Util/BacktraceException.hpp"
 #include<errno.h>
 #include<stdexcept>
 #include<string.h>
@@ -15,19 +16,19 @@ Net::Fd open_rpc_socket( std::string const& lightning_dir
 		       ) {
 	auto chdir_res = chdir(lightning_dir.c_str());
 	if (chdir_res < 0)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("chdir: ") + strerror(errno)
 		);
 
 	auto fd = Net::Fd(socket(AF_UNIX, SOCK_STREAM, 0));
 	if (!fd)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("socket: ") + strerror(errno)
 		);
 
 	auto addr = sockaddr_un();
 	if (rpc_file.length() + 1 > sizeof(addr.sun_path))
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("sizeof(sun_path): ") + strerror(ENOSPC)
 		);
 
@@ -42,7 +43,7 @@ Net::Fd open_rpc_socket( std::string const& lightning_dir
 				     );
 	} while (connect_res < 0 && errno == EINTR);
 	if (connect_res < 0)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("connect: ") + strerror(errno)
 		);
 

--- a/Boss/random_engine.cpp
+++ b/Boss/random_engine.cpp
@@ -1,5 +1,6 @@
 #include"Boss/random_engine.hpp"
 #include"Net/Fd.hpp"
+#include"Util/BacktraceException.hpp"
 #include<errno.h>
 #include<fcntl.h>
 #include<stdexcept>
@@ -18,7 +19,7 @@ std::default_random_engine initialize_random_engine() {
 		dr = Net::Fd(open("/dev/random", O_RDONLY));
 	} while (!dr && errno == EINTR);
 	if (!dr)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("open /dev/random: ") +
 			strerror(errno)
 		);

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Added `Util::BacktraceException` which captures backtraces where an
+  exception is thrown and then formats them for debugging when they
+  are displayed with `what()`.  The backtraces are more useful if the
+  following configuration is used: `./configure CXXFLAGS="-g -Og"` but
+  this results in larger, less optimized binaries.
+
 ## [0.13.3] - 2024-08-09: "Blinded by the Light"
 
 This point release fixes an important bug by restoring the earned fee

--- a/DnsSeed/Detail/decode_bech32_node.cpp
+++ b/DnsSeed/Detail/decode_bech32_node.cpp
@@ -1,4 +1,5 @@
 #include"DnsSeed/Detail/decode_bech32_node.hpp"
+#include"Util/BacktraceException.hpp"
 #include"Util/Bech32.hpp"
 #include<algorithm>
 #include<ctype.h>
@@ -12,19 +13,19 @@ std::vector<std::uint8_t> decode_bech32_node(std::string const& s) {
 	auto bitstream = std::vector<bool>();
 
 	if (!Util::Bech32::decode(hrp, bitstream, s))
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Not a bech32 string: ") + s
 		);
 
 	/* 264 bits needed, but bech32 encodes in batches of 5 bits so
 	 * we round up to 265.  */
 	if (bitstream.size() != 33 * 8 + 1)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Data part wrong size: ") + s
 		);
 	/* The last bit should be 0.  */
 	if (bitstream[264] == 1)
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Odd node id: ") + s
 		);
 	/* And should be removed.  */

--- a/Ev/ThreadPool.cpp
+++ b/Ev/ThreadPool.cpp
@@ -12,6 +12,7 @@
 #include<unistd.h>
 #include<vector>
 #include"Ev/ThreadPool.hpp"
+#include"Util/BacktraceException.hpp"
 #include"Util/make_unique.hpp"
 
 namespace {
@@ -182,7 +183,7 @@ public:
 		int pipes[2];
 		auto pipe_res = pipe(pipes);
 		if (pipe_res < 0) {
-			throw std::runtime_error(std::string("Ev::ThreadPool: pipe:")
+			throw Util::BacktraceException<std::runtime_error>(std::string("Ev::ThreadPool: pipe:")
 						+ strerror(errno)
 						);
 		}

--- a/Ev/runcmd.cpp
+++ b/Ev/runcmd.cpp
@@ -1,6 +1,7 @@
 #include"Ev/Io.hpp"
 #include"Ev/runcmd.hpp"
 #include"Net/Fd.hpp"
+#include"Util/BacktraceException.hpp"
 #include"Util/make_unique.hpp"
 #include<errno.h>
 #include<ev.h>
@@ -62,7 +63,7 @@ private:
 	static
 	void error(std::unique_ptr<RunCmd> self, std::string msg) {
 		try {
-			throw std::runtime_error(
+			throw Util::BacktraceException<Util::BacktraceException<std::runtime_error>>(
 				std::string("pipecmd: ") + msg +
 				": " + strerror(errno)
 			);

--- a/Jsmn/Object.cpp
+++ b/Jsmn/Object.cpp
@@ -386,7 +386,7 @@ std::istream& operator>>(std::istream& is, Jsmn::Object& o) {
 		if (!is || is.eof() || !is.get(buf[0])) {
 			if (!started)
 				return is;
-			throw std::runtime_error("Unexpected end-of-file.");
+			throw Util::BacktraceException<std::runtime_error>("Unexpected end-of-file.");
 		}
 		started = true;
 

--- a/Jsmn/Object.hpp
+++ b/Jsmn/Object.hpp
@@ -7,6 +7,7 @@
 #include<memory>
 #include<ostream>
 #include<stdexcept>
+#include"Util/BacktraceException.hpp"
 #include<string>
 #include<vector>
 
@@ -16,10 +17,9 @@ namespace Jsmn { class ParserExposedBuffer; }
 namespace Jsmn {
 
 /* Thrown when converting or using as incorrect type.  */
-/* FIXME: Use a backtrace-catching exception.  */
-class TypeError : public std::invalid_argument {
+class TypeError : public Util::BacktraceException<std::invalid_argument> {
 public:
-	TypeError() : std::invalid_argument("Incorrect type.") { }
+	TypeError() : Util::BacktraceException<std::invalid_argument>("Incorrect type.") { }
 };
 
 /* Represents an object that has been parsed from a JSON string.  */

--- a/Jsmn/ParseError.hpp
+++ b/Jsmn/ParseError.hpp
@@ -1,6 +1,7 @@
 #ifndef JSMN_PARSEERROR_HPP
 #define JSMN_PARSEERROR_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<stdexcept>
 #include<string>
 #include<utility>
@@ -8,7 +9,7 @@
 namespace Jsmn {
 
 /* Thrown on JSON parsing failure.  */
-class ParseError : public std::runtime_error {
+class ParseError : public Util::BacktraceException<std::runtime_error> {
 private:
 	std::string input;
 	unsigned int i;
@@ -20,7 +21,7 @@ public:
 	ParseError() =delete;
 	ParseError( std::string input_
 		  , unsigned int i_
-		  ) : std::runtime_error(enmessage(input_, i_))
+		  ) : Util::BacktraceException<std::runtime_error>(enmessage(input_, i_))
 		    , input(std::move(input_))
 		    , i(i_)
 		    {

--- a/Ln/Amount.cpp
+++ b/Ln/Amount.cpp
@@ -1,4 +1,5 @@
 #include"Ln/Amount.hpp"
+#include"Util/BacktraceException.hpp"
 #include<algorithm>
 #include<sstream>
 #include<stdexcept>
@@ -44,12 +45,12 @@ Amount::object(Jsmn::Object const& o) {
 	else if (o.is_string())
 		return Amount(std::string(o));
 	else
-		throw std::invalid_argument("Ln::Amount json object invalid.");
+		throw Util::BacktraceException<std::invalid_argument>("Ln::Amount json object invalid.");
 }
 
 Amount::Amount(std::string const& s) {
 	if (!valid_string(s))
-		throw std::invalid_argument("Ln::Amount string invalid.");
+		throw Util::BacktraceException<std::invalid_argument>("Ln::Amount string invalid.");
 	auto is = std::istringstream(std::string(s.begin(), s.end() - 4));
 	is >> v;
 }

--- a/Ln/NodeId.cpp
+++ b/Ln/NodeId.cpp
@@ -19,7 +19,7 @@ namespace Ln {
 NodeId::NodeId(std::string const& s) {
 	/* Parse.  */
 	if (!valid_string(s))
-		throw std::range_error(
+		throw Util::BacktraceException<std::range_error>(
 			std::string("Ln::NodeId: not node ID: ") + s
 		);
 

--- a/Ln/Preimage.cpp
+++ b/Ln/Preimage.cpp
@@ -29,7 +29,7 @@ bool Preimage::valid_string(std::string const& s) {
 Preimage::Preimage(std::string const& s) : pimpl(std::make_shared<Impl>()) {
 	auto buf = Util::Str::hexread(s);
 	if (buf.size() != 32)
-		throw std::invalid_argument("Ln::Preimage: wrong size.");
+		throw Util::BacktraceException<std::invalid_argument>("Ln::Preimage: wrong size.");
 	for (auto i = 0; i < 32; ++i)
 		pimpl->data[i] = buf[i];
 }

--- a/Ln/Scid.cpp
+++ b/Ln/Scid.cpp
@@ -1,4 +1,5 @@
 #include"Ln/Scid.hpp"
+#include"Util/BacktraceException.hpp"
 #include<algorithm>
 #include<sstream>
 #include<stdexcept>
@@ -82,7 +83,7 @@ Scid::Scid(std::string const& s) {
 	auto t = std::uint64_t();
 	auto o = std::uint64_t();
 	if (!validate_and_parse(s, b, t, o))
-		throw std::invalid_argument(std::string("Not an SCID: ") + s);
+		throw Util::BacktraceException<std::invalid_argument>(std::string("Not an SCID: ") + s);
 	val = (b << 40)
 	    | (t << 16)
 	    | (o << 0)

--- a/Makefile.am
+++ b/Makefile.am
@@ -516,6 +516,7 @@ libclboss_la_SOURCES = \
 	Stats/RunningMean.cpp \
 	Stats/RunningMean.hpp \
 	Stats/WeightedMedian.hpp \
+	Util/BacktraceException.hpp \
 	Util/Bech32.cpp \
 	Util/Bech32.hpp \
 	Util/Compiler.hpp \

--- a/Net/IPAddr.hpp
+++ b/Net/IPAddr.hpp
@@ -1,6 +1,7 @@
 #ifndef NET_IPADDR_HPP
 #define NET_IPADDR_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<cstdint>
 #include<memory>
 #include<ostream>
@@ -17,11 +18,11 @@ namespace Net {
  *
  * @brief thrown when an invalid IP address is given.
  */
-class IPAddrInvalid : public std::invalid_argument {
+class IPAddrInvalid : public Util::BacktraceException<std::invalid_argument> {
 public:
 	std::string invalid_ip;
 	explicit IPAddrInvalid( std::string const& invalid_ip_
-			      ) : std::invalid_argument( std::string("Invalid IP: ") 
+		              ) : Util::BacktraceException<std::invalid_argument>( std::string("Invalid IP: ") 
 						       + invalid_ip_
 						       )
 				, invalid_ip(invalid_ip_)

--- a/Net/SocketFd.cpp
+++ b/Net/SocketFd.cpp
@@ -5,6 +5,7 @@
 #include<sys/socket.h>
 #include<unistd.h>
 #include"Net/SocketFd.hpp"
+#include"Util/BacktraceException.hpp"
 
 namespace Net {
 
@@ -59,7 +60,7 @@ void SocketFd::write(std::vector<std::uint8_t> const& data) {
 				     );
 		} while (res < 0 && errno == EINTR);
 		if (res < 0)
-			throw std::runtime_error( std::string("Net::SocketFd::write: write: ")
+			throw Util::BacktraceException<std::runtime_error>( std::string("Net::SocketFd::write: write: ")
 						+ strerror(errno)
 						);
 		ptr += res;
@@ -78,7 +79,7 @@ std::vector<std::uint8_t> SocketFd::read(std::size_t size) {
 				    );
 		} while (res < 0 && errno == EINTR);
 		if (res < 0)
-			throw std::runtime_error( std::string("Net::SocketFd::read: read: ")
+			throw Util::BacktraceException<std::runtime_error>( std::string("Net::SocketFd::read: read: ")
 						+ strerror(errno)
 						);
 		if (res == 0) {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ would be 20x larger!), but if it matters to you, you can
 override the CLBOSS default via `CXXFLAGS`, such as:
 
     ./configure CXXFLAGS="-g -O2"  # or whatever flags you like
+    ./configure CXXFLAGS="-g -Og"  # recommended for debugging
 
 And if your build machine has more than 1 core, you probably
 want to pass in the `-j` option to `make`, too:

--- a/Ripemd160/Hash.cpp
+++ b/Ripemd160/Hash.cpp
@@ -19,7 +19,7 @@ bool Hash::valid_string(std::string const& s) {
 Hash::Hash(std::string const& s) : pimpl(std::make_shared<Impl>()) {
 	auto buf = Util::Str::hexread(s);
 	if (buf.size() != 20)
-		throw std::invalid_argument(
+		throw Util::BacktraceException<std::invalid_argument>(
 			"Ripemd160::Hash: incorrect size."
 		);
 	from_buffer(&buf[0]);

--- a/Secp256k1/Detail/context.cpp
+++ b/Secp256k1/Detail/context.cpp
@@ -2,12 +2,13 @@
 #include<stdexcept>
 #include<string>
 #include"Secp256k1/Detail/context.hpp"
+#include"Util/BacktraceException.hpp"
 
 namespace {
 
 /* Called due to illegal inputs to the library.  */
 void illegal_callback(const char* msg, void*) {
-	throw std::invalid_argument(std::string("SECP256K1: ") + msg);
+	throw Util::BacktraceException<std::invalid_argument>(std::string("SECP256K1: ") + msg);
 }
 
 std::shared_ptr<secp256k1_context_struct> create_secp256k1_context() {

--- a/Secp256k1/PrivKey.cpp
+++ b/Secp256k1/PrivKey.cpp
@@ -68,7 +68,7 @@ PrivKey& PrivKey::operator+=(PrivKey const& o) {
 	auto res = secp256k1_ec_seckey_tweak_add(context.get(), key, o.key);
 	/* FIXME: Use a backtrace-catching exception. */
 	if (!res)
-		throw std::out_of_range("Secp256k1::PrivKey += out-of-range");
+		throw Util::BacktraceException<std::out_of_range>("Secp256k1::PrivKey += out-of-range");
 	return *this;
 }
 
@@ -76,7 +76,7 @@ PrivKey& PrivKey::operator*=(PrivKey const& o) {
 	auto res = secp256k1_ec_seckey_tweak_mul(context.get(), key, o.key);
 	/* FIXME: Use a backtrace-catching exception. */
 	if (!res)
-		throw std::out_of_range("Secp256k1::PrivKey += out-of-range");
+		throw Util::BacktraceException<std::out_of_range>("Secp256k1::PrivKey += out-of-range");
 	return *this;
 }
 

--- a/Secp256k1/PrivKey.hpp
+++ b/Secp256k1/PrivKey.hpp
@@ -1,6 +1,7 @@
 #ifndef SECP256K1_PRIVKEY_HPP
 #define SECP256K1_PRIVKEY_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<cstdint>
 #include<ostream>
 #include<stdexcept>
@@ -19,9 +20,9 @@ namespace Secp256k1 {
  * private key.
  */
 /* FIXME: derive from a backtrace-capturing exception.  */
-class InvalidPrivKey : public std::invalid_argument {
+class InvalidPrivKey : public Util::BacktraceException<std::invalid_argument> {
 public:
-	InvalidPrivKey() : std::invalid_argument("Invalid private key.") {}
+	InvalidPrivKey() : Util::BacktraceException<std::invalid_argument>("Invalid private key.") {}
 };
 
 class PrivKey {

--- a/Secp256k1/PubKey.cpp
+++ b/Secp256k1/PubKey.cpp
@@ -67,7 +67,7 @@ public:
 						      );
 		/* FIXME: use a backtrace-prserving exception.  */
 		if (!res)
-			throw std::out_of_range(
+			throw Util::BacktraceException<std::out_of_range>(
 				"Secp256k1::PubKey::operatoor+=: "
 				"result of adding PubKey out-of-range"
 			);
@@ -83,7 +83,7 @@ public:
 							, sk.key
 							);
 		if (!res)
-			throw std::out_of_range(
+			throw Util::BacktraceException<std::out_of_range>(
 				"Secp256k1::PubKey::operatoor*=: "
 				"result of multiplying PrivKey out-of-range"
 			);

--- a/Secp256k1/PubKey.hpp
+++ b/Secp256k1/PubKey.hpp
@@ -1,6 +1,7 @@
 #ifndef SECP256K1_PUBKEY_HPP
 #define SECP256K1_PUBKEY_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<cstdint>
 #include<functional>
 #include<istream>
@@ -23,9 +24,9 @@ std::ostream& operator<<(std::ostream&, Secp256k1::PubKey const&);
 namespace Secp256k1 {
 
 /* Thrown in case of being fed an invalid public key.  */
-class InvalidPubKey : public std::invalid_argument {
+class InvalidPubKey : public Util::BacktraceException<std::invalid_argument> {
 public:
-	InvalidPubKey() : std::invalid_argument("Invalid public key.") { }
+	InvalidPubKey() : Util::BacktraceException<std::invalid_argument>("Invalid public key.") { }
 };
 
 class PubKey {

--- a/Secp256k1/Signature.cpp
+++ b/Secp256k1/Signature.cpp
@@ -46,7 +46,7 @@ Signature::Signature( Secp256k1::PrivKey const& sk
 			/* Extremely unlikely to happen.
 			 * TODO: backtrace-capturing.
 			 */
-			throw std::runtime_error("Nonce generation for signing failed.");
+			throw Util::BacktraceException<std::runtime_error>("Nonce generation for signing failed.");
 		++(*reinterpret_cast<std::uint64_t*>(extra_entropy));
 	} while (!sig_has_low_r());
 }

--- a/Secp256k1/Signature.hpp
+++ b/Secp256k1/Signature.hpp
@@ -1,6 +1,7 @@
 #ifndef SECP256K1_SIGNATURE_HPP
 #define SECP256K1_SIGNATURE_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<cstdint>
 #include<stdexcept>
 #include<string>
@@ -12,10 +13,11 @@ namespace Sha256 { class Hash; }
 
 namespace Secp256k1 {
 
-class BadSignatureEncoding : public std::invalid_argument {
+
+class BadSignatureEncoding : public Util::BacktraceException<std::invalid_argument> {
 public:
 	BadSignatureEncoding()
-		: std::invalid_argument("Bad signature encoding")
+		: Util::BacktraceException<std::invalid_argument>("Bad signature encoding")
 		{ }
 };
 

--- a/Sha256/Hash.cpp
+++ b/Sha256/Hash.cpp
@@ -17,7 +17,7 @@ bool Hash::valid_string(std::string const& s) {
 Hash::Hash(std::string const& s) {
 	auto bytes = Util::Str::hexread(s);
 	if (bytes.size() != 32)
-		throw std::invalid_argument("Hashes must be 32 bytes.");
+		throw Util::BacktraceException<std::invalid_argument>("Hashes must be 32 bytes.");
 	pimpl = std::make_shared<Impl>();
 	for (auto i = std::size_t(0); i < 32; ++i)
 		pimpl->d[i] = bytes[i];

--- a/Sqlite3/Db.cpp
+++ b/Sqlite3/Db.cpp
@@ -1,5 +1,6 @@
 #include"Ev/Io.hpp"
 #include"Ev/yield.hpp"
+#include"Util/BacktraceException.hpp"
 #include"Sqlite3/Db.hpp"
 #include"Sqlite3/Tx.hpp"
 #include<stdexcept>
@@ -28,7 +29,7 @@ public:
 				connection = nullptr;
 			} else
 				msg = "Not enough memory";
-			throw std::runtime_error(
+			throw Util::BacktraceException<std::runtime_error>(
 				std::string("Sqlite3::Db: sqlite3_open: ") +
 				msg
 			);
@@ -38,7 +39,7 @@ public:
 			auto msg = std::string(sqlite3_errmsg(connection));
 			sqlite3_close_v2(connection);
 			connection = nullptr;
-			throw std::runtime_error(
+			throw Util::BacktraceException<std::runtime_error>(
 				std::string("Sqlite3::Db: sqlite3_extended_result_codes: ") +
 				msg
 			);
@@ -50,7 +51,7 @@ public:
 			auto msg = std::string(sqlite3_errmsg(connection));
 			sqlite3_close_v2(connection);
 			connection = nullptr;
-			throw std::runtime_error(
+			throw Util::BacktraceException<std::runtime_error>(
 				std::string("Sqlite3::Db: "
 					    "PRAGMA foreign_keys = ON: "
 					   ) +

--- a/Sqlite3/Detail/binds.cpp
+++ b/Sqlite3/Detail/binds.cpp
@@ -1,3 +1,4 @@
+#include"Util/BacktraceException.hpp"
 #include"Sqlite3/Detail/binds.hpp"
 #include<sqlite3.h>
 #include<stdexcept>
@@ -9,14 +10,14 @@ void bind_d(void* stmt, int l, double v) {
 				      , l, v
 				      );
 	if (res != SQLITE_OK)
-		throw std::runtime_error("Sqlite3: bind error.");
+		throw Util::BacktraceException<std::runtime_error>("Sqlite3: bind error.");
 }
 void bind_i(void* stmt, int l, std::int64_t v) {
 	auto res = sqlite3_bind_int64( (sqlite3_stmt*) stmt
 				     , l, v
 				     );
 	if (res != SQLITE_OK)
-		throw std::runtime_error("Sqlite3: bind error.");
+		throw Util::BacktraceException<std::runtime_error>("Sqlite3: bind error.");
 }
 void bind_s(void* stmt, int l, std::string v) {
 	auto res = sqlite3_bind_text( (sqlite3_stmt*) stmt
@@ -24,12 +25,12 @@ void bind_s(void* stmt, int l, std::string v) {
 				    , SQLITE_TRANSIENT
 				    );
 	if (res != SQLITE_OK)
-		throw std::runtime_error("Sqlite3: bind error.");
+		throw Util::BacktraceException<std::runtime_error>("Sqlite3: bind error.");
 }
 void bind_null(void* stmt, int l) {
 	auto res = sqlite3_bind_null( (sqlite3_stmt*) stmt, l);
 	if (res != SQLITE_OK)
-		throw std::runtime_error("Sqlite3: bind error.");
+		throw Util::BacktraceException<std::runtime_error>("Sqlite3: bind error.");
 }
 
 }}

--- a/Sqlite3/Query.cpp
+++ b/Sqlite3/Query.cpp
@@ -1,6 +1,7 @@
 #include"Sqlite3/Db.hpp"
 #include"Sqlite3/Query.hpp"
 #include"Sqlite3/Result.hpp"
+#include"Util/BacktraceException.hpp"
 #include"Util/make_unique.hpp"
 #include<sqlite3.h>
 #include<stdexcept>
@@ -27,7 +28,7 @@ public:
 	int get_location(char const* field) const {
 		auto res = sqlite3_bind_parameter_index(stmt, field);
 		if (res == 0)
-			throw std::runtime_error(
+			throw Util::BacktraceException<std::runtime_error>(
 				std::string("Sqlite3::Query::bind: "
 					    "no field: "
 					   ) + field

--- a/Sqlite3/Result.cpp
+++ b/Sqlite3/Result.cpp
@@ -1,3 +1,4 @@
+#include"Util/BacktraceException.hpp"
 #include"Sqlite3/Db.hpp"
 #include"Sqlite3/Result.hpp"
 #include<sqlite3.h>
@@ -30,7 +31,7 @@ bool Result::advance() {
 	else {
 		auto connection = (sqlite3*) db.get_connection();
 		auto err = std::string(sqlite3_errmsg(connection));
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Sqlite3::Result: ") + err
 		);
 	}

--- a/Sqlite3/Tx.cpp
+++ b/Sqlite3/Tx.cpp
@@ -1,6 +1,7 @@
 #include"Sqlite3/Db.hpp"
 #include"Sqlite3/Query.hpp"
 #include"Sqlite3/Tx.hpp"
+#include"Util/BacktraceException.hpp"
 #include"Util/make_unique.hpp"
 #include<stdexcept>
 #include<sqlite3.h>
@@ -15,7 +16,7 @@ private:
 	void throw_sqlite3(char const* src) {
 		auto connection = (sqlite3*) db.get_connection();
 		auto err = std::string(sqlite3_errmsg(connection));
-		throw std::runtime_error(
+		throw Util::BacktraceException<std::runtime_error>(
 			std::string("Sqlite3::Tx: ") + src + ": " + err
 		);
 	}

--- a/Stats/WeightedMedian.hpp
+++ b/Stats/WeightedMedian.hpp
@@ -1,6 +1,7 @@
 #ifndef STATS_WEIGHTEDMEDIAN_HPP
 #define STATS_WEIGHTEDMEDIAN_HPP
 
+#include"Util/BacktraceException.hpp"
 #include<algorithm>
 #include<functional>
 #include<stdexcept>
@@ -14,9 +15,9 @@ namespace Stats {
  * @brief thrown when the weighted-median is
  * extracted but there are no samples.
  */
-class NoSamples : public std::invalid_argument {
+class NoSamples : public Util::BacktraceException<std::invalid_argument> {
 public:
-	NoSamples() : std::invalid_argument("Stats::NoSamples") { }
+	NoSamples() : Util::BacktraceException<std::invalid_argument>("Stats::NoSamples") { }
 };
 
 /** class Stats::WeightedMedian

--- a/Util/BacktraceException.hpp
+++ b/Util/BacktraceException.hpp
@@ -1,0 +1,109 @@
+#ifndef UTIL_BACKTRACE_EXCEPTION_HPP
+#define UTIL_BACKTRACE_EXCEPTION_HPP
+
+#include <array>
+#include <execinfo.h>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <vector>
+#include <string.h>
+
+namespace Util {
+
+/** class Util::BacktraceException<E>
+ *
+ * @brief A wrapper for an exception E which additionally stores a
+ * backtrace when it is constructed.  The backtrace formatting is
+ * deferred until `what()` is called on the handled exception.
+ */
+
+struct PcloseDeleter {
+    void operator()(FILE* fp) const {
+        if (fp) {
+            pclose(fp);
+        }
+    }
+};
+
+template <typename T>
+class BacktraceException : public T {
+public:
+	template <typename... Args>
+	BacktraceException(Args&&... args)
+		: T(std::forward<Args>(args)...), full_message_(T::what()) {
+		capture_backtrace();
+	}
+
+	const char* what() const noexcept override {
+		if (!formatted_) {
+			formatted_ = true;
+			full_message_ = create_full_message(T::what());
+		}
+		return full_message_.c_str();
+	}
+
+private:
+	static constexpr size_t MAX_FRAMES = 100;
+	mutable bool formatted_ = false;
+	mutable std::string full_message_;
+	mutable void* backtrace_addresses_[MAX_FRAMES];
+	mutable size_t stack_depth;
+
+	void capture_backtrace() {
+		memset(backtrace_addresses_, 0, sizeof(backtrace_addresses_));
+		stack_depth = backtrace(backtrace_addresses_, sizeof(backtrace_addresses_) / sizeof(void*));
+	}
+
+	std::string format_backtrace() const {
+		char** symbols = backtrace_symbols(backtrace_addresses_, stack_depth);
+		std::ostringstream oss;
+		for (size_t i = 0; i < stack_depth; ++i) {
+			oss << '#' << std::left << std::setfill(' ') << std::setw(2) << i << ' ';
+			auto line = addr2line(backtrace_addresses_[i]);
+			if (line.find("??") != std::string::npos) {
+				// If addr2line doesn't find a good
+				// answer use basic information
+				// instead.
+				oss << symbols[i] << std::endl;
+			} else {
+				oss << line;
+			}
+		}
+		free(symbols);
+		return oss.str();
+	}
+
+	// Unfortunately there is no simple way to get a high quality
+	// backtrace using in-process libraries.  Instead for now we
+	// popen an addr2line process and use it's output.
+	std::string addr2line(void* addr) const {
+		char cmd[512];
+		snprintf(cmd, sizeof(cmd),
+			 "addr2line -C -f -p -e %s %p", program_invocation_name, addr);
+
+		std::array<char, 128> buffer;
+		std::string result;
+		std::unique_ptr<FILE, PcloseDeleter> pipe(popen(cmd, "r"));
+
+		if (!pipe) {
+			return " -- error: unable to open addr2line";
+		}
+
+		while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+			result += buffer.data();
+		}
+
+		return result;
+	}
+
+	std::string create_full_message(const std::string& message) const {
+		std::ostringstream oss;
+		oss << message << "\nBacktrace:\n" << format_backtrace();
+		return oss.str();
+	}
+};
+
+} // namespace Util
+
+#endif /* UTIL_BACKTRACE_EXCEPTION_HPP */

--- a/Util/Str.hpp
+++ b/Util/Str.hpp
@@ -5,6 +5,7 @@
  * Minor string utilities.
  */
 
+#include"Util/BacktraceException.hpp"
 #include<cstdint>
 #include<stdarg.h>
 #include<stdexcept>
@@ -20,10 +21,9 @@ std::string hexbyte(std::uint8_t);
 std::string hexdump(void const* p, std::size_t s);
 
 /* Creates a buffer from the given hex string.  */
-/* FIXME: use a backtrace-extracting exception. */
-struct HexParseFailure : public std::runtime_error {
+struct HexParseFailure : public Util::BacktraceException<std::runtime_error> {
 	HexParseFailure(std::string msg)
-		: std::runtime_error("hexread: " + msg) { }
+		: Util::BacktraceException<std::runtime_error>("hexread: " + msg) { }
 };
 std::vector<std::uint8_t> hexread(std::string const&);
 

--- a/Uuid.cpp
+++ b/Uuid.cpp
@@ -39,7 +39,7 @@ Uuid::Uuid(std::string const& s) {
 	pimpl = Util::make_unique<Impl>();
 	auto buf = Util::Str::hexread(s);
 	if (buf.size() != 16)
-		throw std::invalid_argument("Uuid: invalid input string.");
+		throw Util::BacktraceException<std::invalid_argument>("Uuid: invalid input string.");
 	std::copy(buf.begin(), buf.end(), pimpl->data);
 }
 bool Uuid::valid_string(std::string const& s) {


### PR DESCRIPTION
## Abstract

Added `Util::BacktraceException` which captures backtraces where an exception is thrown and then formats them for debugging when they are displayed with `what()`.  The backtraces are more useful if the following configuration is used: `./configure CXXFLAGS="-g -Og"` but this results in larger, less optimized binaries.

## Motivation

When an unexpected exception occurs on a user's machine we typically get a very terse "parse error" or similar message.  This PR adds logging of the stack backtrace where the exception was encountered, greatly increasing the likelihood of finding the problem from the reported log alone.

