### PR TITLE
Add time_buckets to EarningsTracker data

### DIFF
--- a/Boss/Mod/EarningsTracker.cpp
+++ b/Boss/Mod/EarningsTracker.cpp
@@ -12,6 +12,8 @@
 #include"S/Bus.hpp"
 #include"Sqlite3.hpp"
 #include"Util/make_unique.hpp"
+
+#include<cmath>
 #include<map>
 
 namespace Boss { namespace Mod {
@@ -294,7 +296,13 @@ public:
 EarningsTracker::EarningsTracker(EarningsTracker&&) =default;
 EarningsTracker::~EarningsTracker() =default;
 
-		EarningsTracker::EarningsTracker(S::Bus& bus, std::function<double()> get_now_ )
+EarningsTracker::EarningsTracker(S::Bus& bus, std::function<double()> get_now_ )
 	: pimpl(Util::make_unique<Impl>(bus, get_now_)) { }
+
+double EarningsTracker::bucket_time(double input_time) {
+	constexpr double seconds_per_day = 24 * 60 * 60;
+	double bucket_start = std::floor(input_time / seconds_per_day) * seconds_per_day;
+	return bucket_start;
+}
 
 }}

--- a/Boss/Mod/EarningsTracker.cpp
+++ b/Boss/Mod/EarningsTracker.cpp
@@ -1,6 +1,11 @@
 #include"Boss/Mod/EarningsTracker.hpp"
+#include"Boss/Msg/CommandFail.hpp"
+#include"Boss/Msg/CommandRequest.hpp"
+#include"Boss/Msg/CommandResponse.hpp"
 #include"Boss/Msg/DbResource.hpp"
 #include"Boss/Msg/ForwardFee.hpp"
+#include"Boss/Msg/ManifestCommand.hpp"
+#include"Boss/Msg/Manifestation.hpp"
 #include"Boss/Msg/ProvideStatus.hpp"
 #include"Boss/Msg/RequestEarningsInfo.hpp"
 #include"Boss/Msg/RequestMoveFunds.hpp"
@@ -15,6 +20,7 @@
 
 #include<cmath>
 #include<map>
+#include<iostream>
 
 namespace Boss { namespace Mod {
 
@@ -54,7 +60,92 @@ private:
 			     >([this](Msg::RequestEarningsInfo const& req) {
 			return Boss::concurrent(request_earnings_info(req));
 		});
-
+		bus.subscribe<Msg::Manifestation
+			     >([this](Msg::Manifestation const& _) {
+			return bus.raise(Msg::ManifestCommand{
+				"clboss-recent-earnings", "[days]",
+				"Show offchain_earnings_tracker data for the most recent {days} "
+				"(default 14 days).",
+				false
+			}) + bus.raise(Msg::ManifestCommand{
+				"clboss-earnings-history", "[nodeid]",
+				"Show earnings and expenditure history for {nodeid} "
+				"(default all nodes)",
+				false
+			});
+		});
+		bus.subscribe<Msg::CommandRequest>([this](Msg::CommandRequest const& req) {
+			auto id = req.id;
+			auto paramfail = [this, id]() {
+				return bus.raise(Msg::CommandFail{
+						id, -32602,
+						"Parameter failure",
+						Json::Out::empty_object()
+					});
+			};
+			if (req.command == "clboss-recent-earnings") {
+				auto days = double(14.0);
+				auto days_j = Jsmn::Object();
+				auto params = req.params;
+				if (params.is_object()) {
+					if (params.size() > 1)
+						return paramfail();
+					if (params.size() == 1) {
+						if (!params.has("days"))
+							return paramfail();
+						days_j = params["days"];
+					}
+				} else if (params.is_array()) {
+					if (params.size() > 1)
+						return paramfail();
+					if (params.size() == 1)
+						days_j = params[0];
+				}
+				if (!days_j.is_null()) {
+					if (!days_j.is_number())
+						return paramfail();
+					days = (double) days_j;
+				}
+				return db.transact().then([this, id, days](Sqlite3::Tx tx) {
+					auto report = recent_earnings_report(tx, days);
+					tx.commit();
+					return bus.raise(Msg::CommandResponse{
+							id, report
+						});
+				});
+			} else if (req.command == "clboss-earnings-history") {
+				auto nodeid = std::string("");
+				auto nodeid_j = Jsmn::Object();
+				auto params = req.params;
+				if (params.is_object()) {
+					if (params.size() > 1)
+						return paramfail();
+					if (params.size() == 1) {
+						if (!params.has("nodeid"))
+							return paramfail();
+						nodeid_j = params["nodeid"];
+					}
+				} else if (params.is_array()) {
+					if (params.size() > 1)
+						return paramfail();
+					if (params.size() == 1)
+						nodeid_j = params[0];
+				}
+				if (!nodeid_j.is_null()) {
+					if (!nodeid_j.is_string())
+						return paramfail();
+					nodeid = (std::string) nodeid_j;
+				}
+				return db.transact().then([this, id, nodeid](Sqlite3::Tx tx) {
+					auto report = earnings_history_report(tx, nodeid);
+					tx.commit();
+					return bus.raise(Msg::CommandResponse{
+							id, report
+						});
+				});
+			}
+			return Ev::lift();
+		});
 		bus.subscribe<Msg::SolicitStatus
 			     >([this](Msg::SolicitStatus const& _) {
 			if (!db)
@@ -346,6 +437,131 @@ private:
 				std::move(out)
 			});
 		});
+	}
+
+	Json::Out recent_earnings_report(Sqlite3::Tx& tx, double days) {
+		auto cutoff = bucket_time(get_now()) - (days * 24 * 60 * 60);
+		auto fetch = tx.query(R"QRY(
+        		SELECT node,
+        		       SUM(in_earnings) AS total_in_earnings,
+        		       SUM(in_expenditures) AS total_in_expenditures,
+        		       SUM(out_earnings) AS total_out_earnings,
+        		       SUM(out_expenditures) AS total_out_expenditures
+        		  FROM "EarningsTracker"
+                         WHERE time_bucket >= :cutoff
+        		 GROUP BY node
+                         ORDER BY (total_in_earnings - total_in_expenditures +
+                                   total_out_earnings - total_out_expenditures) DESC;
+			)QRY")
+			.bind(":cutoff", cutoff)
+			.execute()
+			;
+		auto out = Json::Out();
+		auto top = out.start_object();
+		auto recent = top.start_object("recent");
+		uint64_t total_in_earnings = 0;
+		uint64_t total_in_expenditures = 0;
+		uint64_t total_out_earnings = 0;
+		uint64_t total_out_expenditures = 0;
+		for (auto& r : fetch) {
+			auto in_earnings = r.get<std::uint64_t>(1);
+			auto in_expenditures = r.get<std::uint64_t>(2);
+			auto out_earnings = r.get<std::uint64_t>(3);
+			auto out_expenditures = r.get<std::uint64_t>(4);
+			auto sub = recent.start_object(r.get<std::string>(0));
+			sub
+				.field("in_earnings", in_earnings)
+				.field("in_expenditures", in_expenditures)
+				.field("out_earnings", out_earnings)
+				.field("out_expenditures", out_expenditures)
+				;
+			sub.end_object();
+			total_in_earnings += in_earnings;
+			total_in_expenditures += in_expenditures;
+			total_out_earnings += out_earnings;
+			total_out_expenditures += out_expenditures;
+		}
+		recent.end_object();
+		auto total = top.start_object("total");
+		total
+			.field("in_earnings", total_in_earnings)
+			.field("in_expenditures", total_in_expenditures)
+			.field("out_earnings", total_out_earnings)
+			.field("out_expenditures", total_out_expenditures)
+			;
+		total.end_object();
+		top.end_object();
+		return out;
+	}
+
+	Json::Out earnings_history_report(Sqlite3::Tx& tx, std::string nodeid) {
+		std::string sql;
+		if (nodeid.empty()) {
+		        sql = R"QRY(
+		            SELECT time_bucket,
+		                   SUM(in_earnings) AS total_in_earnings,
+		                   SUM(in_expenditures) AS total_in_expenditures,
+		                   SUM(out_earnings) AS total_out_earnings,
+		                   SUM(out_expenditures) AS total_out_expenditures
+		              FROM "EarningsTracker"
+		             GROUP BY time_bucket
+		             ORDER BY time_bucket;
+		        )QRY";
+		} else {
+		        sql = R"QRY(
+		            SELECT time_bucket,
+		                   in_earnings,
+		                   in_expenditures,
+		                   out_earnings,
+		                   out_expenditures
+		              FROM "EarningsTracker"
+		             WHERE node = :nodeid
+		             ORDER BY time_bucket;
+		        )QRY";
+		}
+		auto query = tx.query(sql.c_str());
+		if (!nodeid.empty()) {
+			query.bind(":nodeid", nodeid);
+		}
+		auto fetch = query.execute();
+
+		auto out = Json::Out();
+		auto top = out.start_object();
+		auto history = top.start_array("history");
+		uint64_t total_in_earnings = 0;
+		uint64_t total_in_expenditures = 0;
+		uint64_t total_out_earnings = 0;
+		uint64_t total_out_expenditures = 0;
+		for (auto& r : fetch) {
+			auto in_earnings = r.get<std::uint64_t>(1);
+			auto in_expenditures = r.get<std::uint64_t>(2);
+			auto out_earnings = r.get<std::uint64_t>(3);
+			auto out_expenditures = r.get<std::uint64_t>(4);
+			auto sub = history.start_object();
+			sub
+				.field("bucket_time", static_cast<std::uint64_t>(r.get<double>(0)))
+				.field("in_earnings", in_earnings)
+				.field("in_expenditures", in_expenditures)
+				.field("out_earnings", out_earnings)
+				.field("out_expenditures", out_expenditures)
+				;
+			sub.end_object();
+			total_in_earnings += in_earnings;
+			total_in_expenditures += in_expenditures;
+			total_out_earnings += out_earnings;
+			total_out_expenditures += out_expenditures;
+		}
+		history.end_array();
+		auto total = top.start_object("total");
+		total
+			.field("in_earnings", total_in_earnings)
+			.field("in_expenditures", total_in_expenditures)
+			.field("out_earnings", total_out_earnings)
+			.field("out_expenditures", total_out_expenditures)
+			;
+		total.end_object();
+		top.end_object();
+		return out;
 	}
 
 public:

--- a/Boss/Mod/EarningsTracker.cpp
+++ b/Boss/Mod/EarningsTracker.cpp
@@ -19,6 +19,7 @@ namespace Boss { namespace Mod {
 class EarningsTracker::Impl {
 private:
 	S::Bus& bus;
+	std::function<double()> get_now;
 	Sqlite3::Db db;
 
 	/* Information of a pending MoveFunds.  */
@@ -287,13 +288,13 @@ public:
 	Impl(Impl const&) =delete;
 
 	explicit
-	Impl(S::Bus& bus_) : bus(bus_) { start(); }
+	Impl(S::Bus& bus_, std::function<double()> get_now_) : bus(bus_), get_now(std::move(get_now_)) { start(); }
 };
 
 EarningsTracker::EarningsTracker(EarningsTracker&&) =default;
 EarningsTracker::~EarningsTracker() =default;
 
-EarningsTracker::EarningsTracker(S::Bus& bus)
-	: pimpl(Util::make_unique<Impl>(bus)) { }
+		EarningsTracker::EarningsTracker(S::Bus& bus, std::function<double()> get_now_ )
+	: pimpl(Util::make_unique<Impl>(bus, get_now_)) { }
 
 }}

--- a/Boss/Mod/EarningsTracker.hpp
+++ b/Boss/Mod/EarningsTracker.hpp
@@ -31,6 +31,9 @@ public:
 
 	explicit
 	EarningsTracker(S::Bus& bus, std::function<double()> get_now_ = &Ev::now);
+
+	// exposed for unit testing, otherwise internal
+	static double bucket_time(double input_time);
 };
 
 }}

--- a/Boss/Mod/EarningsTracker.hpp
+++ b/Boss/Mod/EarningsTracker.hpp
@@ -1,6 +1,8 @@
 #ifndef BOSS_MOD_EARNINGSTRACKER_HPP
 #define BOSS_MOD_EARNINGSTRACKER_HPP
 
+#include"Ev/now.hpp"
+#include<functional>
 #include<memory>
 
 namespace S { class Bus; }
@@ -28,7 +30,7 @@ public:
 	~EarningsTracker();
 
 	explicit
-	EarningsTracker(S::Bus& bus);
+	EarningsTracker(S::Bus& bus, std::function<double()> get_now_ = &Ev::now);
 };
 
 }}

--- a/Jsmn/Object.cpp
+++ b/Jsmn/Object.cpp
@@ -302,6 +302,13 @@ Detail::Iterator Object::end() const {
 	return pimpl->end();
 }
 
+Object Object::parse_json(char const* txt) {
+	auto is = std::istringstream(std::string(txt));
+	auto js = Jsmn::Object();
+	is >> js;
+	return js;
+}
+
 /* Implements indented printing.  */
 namespace {
 

--- a/Jsmn/Object.cpp
+++ b/Jsmn/Object.cpp
@@ -309,6 +309,52 @@ Object Object::parse_json(char const* txt) {
 	return js;
 }
 
+bool Object::operator==(Object const& other) const {
+	if (this == &other) {
+		return true;
+	}
+
+	// Compare types first
+	if (is_null() != other.is_null() || is_boolean() != other.is_boolean() ||
+	    is_string() != other.is_string() || is_object() != other.is_object() ||
+	    is_array() != other.is_array() || is_number() != other.is_number()) {
+		return false;
+	}
+
+	// Compare values based on type
+	if (is_null()) {
+		return true; // Both are null
+	} else if (is_boolean()) {
+		return static_cast<bool>(*this) == static_cast<bool>(other);
+	} else if (is_string()) {
+		return static_cast<std::string>(*this) == static_cast<std::string>(other);
+	} else if (is_number()) {
+		return static_cast<double>(*this) == static_cast<double>(other);
+	} else if (is_object()) {
+		if (size() != other.size()) {
+			return false;
+		}
+		for (const auto& key : keys()) {
+			if (!other.has(key) || (*this)[key] != other[key]) {
+				return false;
+			}
+		}
+		return true;
+	} else if (is_array()) {
+		if (size() != other.size()) {
+			return false;
+		}
+		for (std::size_t i = 0; i < size(); ++i) {
+			if ((*this)[i] != other[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	return false; // Fallback, should not reach here
+}
+
 /* Implements indented printing.  */
 namespace {
 

--- a/Jsmn/Object.hpp
+++ b/Jsmn/Object.hpp
@@ -71,6 +71,11 @@ public:
 	Object operator[](std::size_t) const; /* Return null if out-of-range.  */
 	/* TODO: Iterator.  */
 
+	bool operator==(Object const& other) const;
+	bool operator!=(Object const& other) const {
+		return !(*this == other);
+	}
+
 	/* Formal factory.  */
 	friend class ParserExposedBuffer;
 	/* Iterator type.  */

--- a/Jsmn/Object.hpp
+++ b/Jsmn/Object.hpp
@@ -42,6 +42,8 @@ public:
 	Object& operator=(Object const&) =default;
 	Object& operator=(Object&&) =default;
 
+	static Object parse_json(char const* txt);
+
 	/* Type queries on the object.  */
 	bool is_null() const;
 	bool is_boolean() const;

--- a/Makefile.am
+++ b/Makefile.am
@@ -621,6 +621,7 @@ TESTS = \
 	tests/ev/test_semaphore \
 	tests/ev/test_throw_in_then \
 	tests/graph/test_dijkstra \
+	tests/jsmn/test_equality \
 	tests/jsmn/test_iterator \
 	tests/jsmn/test_parser \
 	tests/jsmn/test_performance \

--- a/Makefile.am
+++ b/Makefile.am
@@ -599,6 +599,8 @@ TESTS = \
 	tests/boss/test_needsconnectsolicitor \
 	tests/boss/test_onchainfeemonitor_samples_init \
 	tests/boss/test_peerjudge_agetracker \
+	tests/boss/test_recentearnings \
+	tests/boss/test_earningshistory \
 	tests/boss/test_peerjudge_algo \
 	tests/boss/test_peerjudge_datagatherer \
 	tests/boss/test_peerstatistician \

--- a/Makefile.am
+++ b/Makefile.am
@@ -590,6 +590,7 @@ TESTS = \
 	tests/boss/test_channelcreator_rearrangerbysize \
 	tests/boss/test_channelcreator_reprioritizer \
 	tests/boss/test_earningsrebalancer \
+	tests/boss/test_earningstracker \
 	tests/boss/test_feemodderbypricetheory \
 	tests/boss/test_forwardfeemonitor \
 	tests/boss/test_getmanifest \

--- a/README.md
+++ b/README.md
@@ -356,6 +356,36 @@ Earlier versions do not record, so if you have been using CLBOSS
 before 0.11D, then historical offchain-to-onchain swaps are not
 reported.
 
+### `clboss-recent-earnings`, `clboss-earnings-history`
+
+As of CLBOSS version [TBD], earnings and expenditures are tracked on a daily basis.
+The following commands have been added to observe the new data:
+
+- **`clboss-recent-earnings`**:
+  - **Purpose**: Returns a data structure equivalent to the
+    `offchain_earnings_tracker` collection in `clboss-status`, but
+    only includes recent earnings and expenditures.
+  - **Arguments**:
+    - `days` (optional): Specifies the number of days to include in
+      the report. Defaults to a fortnight (14 days) if not provided.
+
+- **`clboss-earnings-history`**:
+  - **Purpose**: Provides a daily breakdown of earnings and expenditures.
+  - **Arguments**:
+    - `nodeid` (optional): Limits the history to a particular node if
+      provided. Without this argument, the values are accumulated
+      across all peers.
+  - **Output**: 
+    - The history consists of an array of records showing the earnings
+      and expenditures for each day.
+    - The history includes an initial record with a time value of 0,
+      which contains any legacy earnings and expenditures collected by
+      CLBOSS before daily tracking was implemented.
+
+These commands enhance the tracking of financial metrics, allowing for
+detailed and recent analysis of earnings and expenditures on a daily
+basis.
+
 ### `--clboss-min-onchain=<satoshis>`
 
 Pass this option to `lightningd` in order to specify a target

--- a/Util/Either.hpp
+++ b/Util/Either.hpp
@@ -2,6 +2,7 @@
 #define UTIL_EITHER_HPP
 
 #include<cstdint>
+#include<iostream>
 #include<utility>
 
 namespace Util {
@@ -225,6 +226,19 @@ bool operator<=(Util::Either<L,R> const& a, Util::Either<L,R> const& b) {
 	return !(b < a);
 }
 
+template<typename L, typename R>
+std::ostream& operator<<(std::ostream& os, const Either<L, R>& either) {
+    either.cmatch(
+        [&](const L& l) {
+            os << "Left(" << l << ")";
+        },
+        [&](const R& r) {
+            os << "Right(" << r << ")";
+        }
+    );
+    return os;
 }
+
+} // namespace Util
 
 #endif /* !defined(UTIL_EITHER_HPP) */

--- a/tests/boss/test_availablerpccommandsannouncer.cpp
+++ b/tests/boss/test_availablerpccommandsannouncer.cpp
@@ -25,6 +25,12 @@ auto const help = std::string(R"JSON(
   , { "command": "clboss-unmanage nodeid tags"
     , "category": "plugin"
     }
+  , { "command": "clboss-recent-earnings [days]"
+    , "category": "plugin"
+    }
+  , { "command": "clboss-earnings-history [nodeid]"
+    , "category": "plugin"
+    }
   ]
 }
 )JSON");
@@ -73,6 +79,10 @@ int main() {
 		assert(commands["clboss-status"].usage == "");
 		assert(commands["clboss-ignore-onchain"].usage == "[hours]");
 		assert(commands["clboss-unmanage"].usage == "nodeid tags");
+		assert(commands.count("clboss-recent-earnings") != 0);
+		assert(commands["clboss-recent-earnings"].usage == "[days]");
+		assert(commands.count("clboss-earnings-history") != 0);
+		assert(commands["clboss-earnings-history"].usage == "[nodeid]");
 
 		return Ev::lift();
 	});

--- a/tests/boss/test_earningshistory.cpp
+++ b/tests/boss/test_earningshistory.cpp
@@ -1,0 +1,232 @@
+#undef NDEBUG
+
+#include"Boss/Mod/EarningsTracker.hpp"
+#include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/ForwardFee.hpp"
+#include"Boss/Msg/RequestMoveFunds.hpp"
+#include"Boss/Msg/ResponseMoveFunds.hpp"
+#include"Boss/Msg/CommandResponse.hpp"
+#include"Boss/Msg/CommandRequest.hpp"
+#include"Ev/start.hpp"
+#include"Jsmn/Object.hpp"
+#include"Jsmn/Parser.hpp"
+#include"Json/Out.hpp"
+#include"Ln/NodeId.hpp"
+#include"S/Bus.hpp"
+#include"Sqlite3.hpp"
+
+#include <cassert>
+#include<iostream>
+#include<sstream>
+
+namespace {
+auto const A = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000001");
+auto const B = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000002");
+auto const C = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000003");
+}
+
+double mock_now = 0.0;
+double mock_get_now() {
+	return mock_now;
+}
+
+Ev::Io<void> raiseForwardFeeLoop(S::Bus& bus, int count) {
+	// Creates a series of forwards, one per hour
+	if (count == 0) {
+		return Ev::lift();
+	}
+	return bus.raise(Boss::Msg::ForwardFee{
+			A,              	// in_id
+			B,              	// out_id
+			Ln::Amount::sat(1),	// fee
+			1.0             	// resolution_time
+		})
+		.then([&, count]() {
+			mock_now += 60 * 60;
+			return raiseForwardFeeLoop(bus, count - 1);
+		});
+}
+
+Ev::Io<void> raiseMoveFundsLoop(S::Bus& bus, int count) {
+	if (count == 0) {
+		return Ev::lift();
+	}
+	return bus.raise(
+		Boss::Msg::RequestMoveFunds{
+			nullptr,        	// requester (match ResponseMoveFunds)
+			C,              	// source
+			A,              	// destination
+			Ln::Amount::sat(1000),  // amount
+			Ln::Amount::sat(3)      // fee_budget
+		})
+		.then([&bus]() {
+			return bus.raise(
+				Boss::Msg::ResponseMoveFunds{
+					nullptr,        	// requester (see RequestMoveFunds)
+					Ln::Amount::sat(1000),  // amount_moved
+					Ln::Amount::sat(2)      // fee_spent
+				});
+		})
+		.then([&bus, count]() {
+			mock_now += 24 * 60 * 60; // advance one day
+			return raiseMoveFundsLoop(bus, count - 1);
+		});
+}
+
+int main() {
+	auto bus = S::Bus();
+
+	/* Module under test */
+	Boss::Mod::EarningsTracker mut(bus, &mock_get_now);
+
+	auto db = Sqlite3::Db(":memory:");
+
+	auto req_id = std::uint64_t();
+	auto lastRsp = Boss::Msg::CommandResponse{};
+	auto rsp = false;
+	bus.subscribe<Boss::Msg::CommandResponse>([&](Boss::Msg::CommandResponse const& m) {
+		lastRsp = m;
+		rsp = true;
+		return Ev::yield();
+	});
+
+
+	auto code = Ev::lift().then([&]() {
+		return bus.raise(Boss::Msg::DbResource{ db });
+	}).then([&]() {
+		// Insert 2 months of one fee per hour
+		mock_now = 1722902400; // stroke of midnight
+		return raiseForwardFeeLoop(bus, 24 * 60);
+	}).then([&]() {
+		// Rewind 1 week and add 7 days of one rebalance per day
+		mock_now -= (7 * 24 * 60 * 60);
+		return raiseMoveFundsLoop(bus, 7);
+	}).then([&]() {
+		// Check history for all peers
+		++req_id;
+		return bus.raise(Boss::Msg::CommandRequest{
+				"clboss-earnings-history",
+				Jsmn::Object(),
+				Ln::CommandId::left(req_id)
+			});
+	}).then([&]() {
+		// std::cerr << lastRsp.response.output() << std::endl;
+		assert(rsp);
+		assert(lastRsp.id == Ln::CommandId::left(req_id));
+		auto result = Jsmn::Object::parse_json(lastRsp.response.output().c_str());
+		assert(result["history"].size() == 60);
+		assert(result["history"][0] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1722902400,
+			  "in_earnings": 24000,
+			  "in_expenditures": 0,
+			  "out_earnings": 24000,
+			  "out_expenditures": 0
+			}
+                )JSON"));
+		assert(result["history"][59] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1728000000,
+			  "in_earnings": 24000,
+			  "in_expenditures": 2000,
+			  "out_earnings": 24000,
+			  "out_expenditures": 2000
+			}
+                )JSON"));
+		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "in_earnings": 1440000,
+			  "in_expenditures": 14000,
+			  "out_earnings": 1440000,
+			  "out_expenditures": 14000
+			}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		// Check history for peer A
+		++req_id;
+		return bus.raise(Boss::Msg::CommandRequest{
+				"clboss-earnings-history",
+				Jsmn::Object::parse_json(R"JSON(["020000000000000000000000000000000000000000000000000000000000000001"])JSON"),
+				Ln::CommandId::left(req_id)
+			});
+	}).then([&]() {
+		// std::cerr << lastRsp.response.output() << std::endl;
+		assert(rsp);
+		assert(lastRsp.id == Ln::CommandId::left(req_id));
+		auto result = Jsmn::Object::parse_json(lastRsp.response.output().c_str());
+		assert(result["history"].size() == 60);
+		assert(result["history"][0] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1722902400,
+			  "in_earnings": 24000,
+			  "in_expenditures": 0,
+			  "out_earnings": 0,
+			  "out_expenditures": 0
+			}
+                )JSON"));
+		assert(result["history"][59] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1728000000,
+			  "in_earnings": 24000,
+			  "in_expenditures": 0,
+			  "out_earnings": 0,
+			  "out_expenditures": 2000
+			}
+                )JSON"));
+		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "in_earnings": 1440000,
+			  "in_expenditures": 0,
+			  "out_earnings": 0,
+			  "out_expenditures": 14000
+			}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		// Check history for peer C (should only be one week)
+		++req_id;
+		return bus.raise(Boss::Msg::CommandRequest{
+				"clboss-earnings-history",
+				Jsmn::Object::parse_json(R"JSON(["020000000000000000000000000000000000000000000000000000000000000003"])JSON"),
+				Ln::CommandId::left(req_id)
+			});
+	}).then([&]() {
+		// std::cerr << lastRsp.response.output() << std::endl;
+		assert(rsp);
+		assert(lastRsp.id == Ln::CommandId::left(req_id));
+		auto result = Jsmn::Object::parse_json(lastRsp.response.output().c_str());
+		assert(result["history"].size() == 7);
+		assert(result["history"][0] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1727481600,
+			  "in_earnings": 0,
+			  "in_expenditures": 2000,
+			  "out_earnings": 0,
+			  "out_expenditures": 0
+			}
+                )JSON"));
+		assert(result["history"][6] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1728000000,
+			  "in_earnings": 0,
+			  "in_expenditures": 2000,
+			  "out_earnings": 0,
+			  "out_expenditures": 0
+			}
+                )JSON"));
+		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "in_earnings": 0,
+			  "in_expenditures": 14000,
+			  "out_earnings": 0,
+			  "out_expenditures": 0
+			}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		return Ev::lift(0);
+	});
+
+	return Ev::start(std::move(code));
+}

--- a/tests/boss/test_earningstracker.cpp
+++ b/tests/boss/test_earningstracker.cpp
@@ -1,0 +1,202 @@
+#undef NDEBUG
+
+#include"Boss/Mod/EarningsTracker.hpp"
+#include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/ForwardFee.hpp"
+#include"Boss/Msg/ProvideStatus.hpp"
+#include"Boss/Msg/RequestEarningsInfo.hpp"
+#include"Boss/Msg/RequestMoveFunds.hpp"
+#include"Boss/Msg/ResponseEarningsInfo.hpp"
+#include"Boss/Msg/ResponseMoveFunds.hpp"
+#include"Boss/Msg/SolicitStatus.hpp"
+#include"Ev/start.hpp"
+#include"Jsmn/Object.hpp"
+#include"Jsmn/Parser.hpp"
+#include"Json/Out.hpp"
+#include"Ln/NodeId.hpp"
+#include"S/Bus.hpp"
+#include"Sqlite3.hpp"
+
+#include <cassert>
+#include<iostream>
+#include<sstream>
+
+namespace {
+auto const A = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000001");
+auto const B = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000002");
+auto const C = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000003");
+}
+
+int main() {
+	auto bus = S::Bus();
+
+	/* Module under test */
+	Boss::Mod::EarningsTracker mut(bus);
+
+	auto db = Sqlite3::Db(":memory:");
+
+	Boss::Msg::ProvideStatus lastStatus;
+	Boss::Msg::ResponseEarningsInfo lastEarningsInfo;
+
+	bus.subscribe<Boss::Msg::ProvideStatus>([&](Boss::Msg::ProvideStatus const& st) {
+		lastStatus = st;
+		return Ev::lift();
+	});
+
+	bus.subscribe<Boss::Msg::ResponseEarningsInfo>([&](Boss::Msg::ResponseEarningsInfo const& ei) {
+		lastEarningsInfo = ei;
+		return Ev::lift();
+	});
+
+	auto code = Ev::lift().then([&]() {
+		return bus.raise(Boss::Msg::DbResource{ db });
+	}).then([&]() {
+		return bus.raise(
+			Boss::Msg::ForwardFee{
+				A,			// in_id
+				B,			// out_id
+				Ln::Amount::sat(1),	// fee
+				1.0			// resolution_time
+			});
+	}).then([&]() {
+		return bus.raise(Boss::Msg::SolicitStatus{});
+	}).then([&]() {
+		// std::cerr << lastStatus.value.output() << std::endl;
+		assert(lastStatus.key == "offchain_earnings_tracker");
+		assert(
+			Jsmn::Object::parse_json(lastStatus.value.output().c_str()) ==
+			Jsmn::Object::parse_json(R"JSON(
+		{
+		  "020000000000000000000000000000000000000000000000000000000000000001": {
+		    "in_earnings": 1000,
+		    "in_expenditures": 0,
+		    "out_earnings": 0,
+		    "out_expenditures": 0
+		  },
+		  "020000000000000000000000000000000000000000000000000000000000000002": {
+		    "in_earnings": 0,
+		    "in_expenditures": 0,
+		    "out_earnings": 1000,
+		    "out_expenditures": 0
+		  },
+		  "total": {
+		    "in_earnings": 1000,
+		    "in_expenditures": 0,
+		    "out_earnings": 1000,
+		    "out_expenditures": 0
+		  }
+		}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		return bus.raise(
+			Boss::Msg::ForwardFee{
+				A,			// in_id
+				B,			// out_id
+				Ln::Amount::sat(1),	// fee
+				1.0			// resolution_time
+			});
+	}).then([&]() {
+		return bus.raise(Boss::Msg::SolicitStatus{});
+	}).then([&]() {
+		// std::cerr << lastStatus.value.output() << std::endl;
+		assert(lastStatus.key == "offchain_earnings_tracker");
+		assert(
+			Jsmn::Object::parse_json(lastStatus.value.output().c_str()) ==
+			Jsmn::Object::parse_json(R"JSON(
+		{
+		  "020000000000000000000000000000000000000000000000000000000000000001": {
+		    "in_earnings": 2000,
+		    "in_expenditures": 0,
+		    "out_earnings": 0,
+		    "out_expenditures": 0
+		  },
+		  "020000000000000000000000000000000000000000000000000000000000000002": {
+		    "in_earnings": 0,
+		    "in_expenditures": 0,
+		    "out_earnings": 2000,
+		    "out_expenditures": 0
+		  },
+		  "total": {
+		    "in_earnings": 2000,
+		    "in_expenditures": 0,
+		    "out_earnings": 2000,
+		    "out_expenditures": 0
+		  }
+		}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		return bus.raise(
+			Boss::Msg::RequestMoveFunds{
+				NULL,			// requester (match ResponseMoveFunds)
+				C,			// source
+				A,			// destination
+				Ln::Amount::sat(1000),	// amount
+				Ln::Amount::sat(3)	// fee_budget
+			});
+	}).then([&]() {
+		return bus.raise(
+			Boss::Msg::ResponseMoveFunds{
+				NULL,			// requester (match RequestMoveFunds)
+				Ln::Amount::sat(1000),	// amount_moved
+				Ln::Amount::sat(2)	// fee_spent
+			});
+	}).then([&]() {
+		return bus.raise(Boss::Msg::SolicitStatus{});
+	}).then([&]() {
+		// std::cerr << lastStatus.value.output() << std::endl;
+		assert(lastStatus.key == "offchain_earnings_tracker");
+		assert(
+			Jsmn::Object::parse_json(lastStatus.value.output().c_str()) ==
+			Jsmn::Object::parse_json(R"JSON(
+		{
+		  "020000000000000000000000000000000000000000000000000000000000000001": {
+		    "in_earnings": 2000,
+		    "in_expenditures": 0,
+		    "out_earnings": 0,
+		    "out_expenditures": 2000
+		  },
+		  "020000000000000000000000000000000000000000000000000000000000000002": {
+		    "in_earnings": 0,
+		    "in_expenditures": 0,
+		    "out_earnings": 2000,
+		    "out_expenditures": 0
+		  },
+		  "020000000000000000000000000000000000000000000000000000000000000003": {
+		    "in_earnings": 0,
+		    "in_expenditures": 2000,
+		    "out_earnings": 0,
+		    "out_expenditures": 0
+		  },
+		  "total": {
+		    "in_earnings": 2000,
+		    "in_expenditures": 2000,
+		    "out_earnings": 2000,
+		    "out_expenditures": 2000
+		  }
+		}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		mock_now = 4000.0;
+		return bus.raise(
+			Boss::Msg::RequestEarningsInfo{
+				NULL,			// requester (match ResponseEarningsInfo)
+				A			// node
+			});
+	}).then([&]() {
+		return Ev::yield(42);
+	}).then([&]() {
+		assert(lastEarningsInfo.node == A);
+		assert(lastEarningsInfo.in_earnings == Ln::Amount::msat(2000));
+		assert(lastEarningsInfo.in_expenditures == Ln::Amount::msat(0));
+		assert(lastEarningsInfo.out_earnings == Ln::Amount::msat(0));
+		assert(lastEarningsInfo.out_expenditures == Ln::Amount::msat(2000));
+		return Ev::lift();
+	}).then([&]() {
+		return Ev::lift(0);
+	});
+
+	return Ev::start(std::move(code));
+}

--- a/tests/boss/test_earningstracker.cpp
+++ b/tests/boss/test_earningstracker.cpp
@@ -27,11 +27,16 @@ auto const B = Ln::NodeId("02000000000000000000000000000000000000000000000000000
 auto const C = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000003");
 }
 
+double mock_now = 0.0;
+double mock_get_now() {
+	return mock_now;
+}
+
 int main() {
 	auto bus = S::Bus();
 
 	/* Module under test */
-	Boss::Mod::EarningsTracker mut(bus);
+	Boss::Mod::EarningsTracker mut(bus, &mock_get_now);
 
 	auto db = Sqlite3::Db(":memory:");
 
@@ -51,6 +56,7 @@ int main() {
 	auto code = Ev::lift().then([&]() {
 		return bus.raise(Boss::Msg::DbResource{ db });
 	}).then([&]() {
+		mock_now = 1000.0;
 		return bus.raise(
 			Boss::Msg::ForwardFee{
 				A,			// in_id
@@ -59,6 +65,7 @@ int main() {
 				1.0			// resolution_time
 			});
 	}).then([&]() {
+		mock_now = 2000.0;
 		return bus.raise(Boss::Msg::SolicitStatus{});
 	}).then([&]() {
 		// std::cerr << lastStatus.value.output() << std::endl;
@@ -89,6 +96,7 @@ int main() {
                         )JSON"));
 		return Ev::lift();
 	}).then([&]() {
+		mock_now = 3000.0;
 		return bus.raise(
 			Boss::Msg::ForwardFee{
 				A,			// in_id
@@ -127,6 +135,7 @@ int main() {
                         )JSON"));
 		return Ev::lift();
 	}).then([&]() {
+		mock_now = 4000.0;
 		return bus.raise(
 			Boss::Msg::RequestMoveFunds{
 				NULL,			// requester (match ResponseMoveFunds)
@@ -136,6 +145,7 @@ int main() {
 				Ln::Amount::sat(3)	// fee_budget
 			});
 	}).then([&]() {
+		mock_now = 5000.0;
 		return bus.raise(
 			Boss::Msg::ResponseMoveFunds{
 				NULL,			// requester (match RequestMoveFunds)

--- a/tests/boss/test_earningstracker.cpp
+++ b/tests/boss/test_earningstracker.cpp
@@ -33,6 +33,12 @@ double mock_get_now() {
 }
 
 int main() {
+	// check the UTC quantitization boundaries
+	assert(Boss::Mod::EarningsTracker::bucket_time(1722902400 - 1)		== 1722816000);
+	assert(Boss::Mod::EarningsTracker::bucket_time(1722902400)		== 1722902400);
+	assert(Boss::Mod::EarningsTracker::bucket_time(1722902400 + 86400 - 1)  == 1722902400);
+	assert(Boss::Mod::EarningsTracker::bucket_time(1722902400 + 86400)      == 1722988800);
+
 	auto bus = S::Bus();
 
 	/* Module under test */

--- a/tests/boss/test_forwardfeemonitor.cpp
+++ b/tests/boss/test_forwardfeemonitor.cpp
@@ -52,13 +52,6 @@ auto const listpeers_result = R"JSON(
 }
 )JSON";
 
-Jsmn::Object parse_json(char const* txt) {
-	auto is = std::istringstream(std::string(txt));
-	auto js = Jsmn::Object();
-	is >> js;
-	return js;
-}
-
 }
 
 int main() {
@@ -103,14 +96,14 @@ int main() {
 
 		/* Give the peers.  */
 		return bus.raise(Boss::Msg::ListpeersResult{
-				Boss::Mod::convert_legacy_listpeers(parse_json(listpeers_result)["peers"]), true
+				Boss::Mod::convert_legacy_listpeers(Jsmn::Object::parse_json(listpeers_result)["peers"]), true
 		});
 	}).then([&]() {
 
 		/* Should ignore non-forward_event.  */
 		forwardfee = nullptr;
 		return bus.raise(Boss::Msg::Notification{
-			"not-forward_event", parse_json("{}")
+			"not-forward_event", Jsmn::Object::parse_json("{}")
 		});
 	}).then([&]() {
 		return Ev::yield(42);
@@ -121,7 +114,7 @@ int main() {
 		forwardfee = nullptr;
 		return bus.raise(Boss::Msg::Notification{
 			"forward_event",
-			parse_json(R"JSON(
+			Jsmn::Object::parse_json(R"JSON(
 {
   "forward_event": {
     "payment_hash": "f5a6a059a25d1e329d9b094aeeec8c2191ca037d3f5b0662e21ae850debe8ea2",

--- a/tests/boss/test_jitrebalancer.cpp
+++ b/tests/boss/test_jitrebalancer.cpp
@@ -169,13 +169,6 @@ public:
 			    ) : bus(bus_) { start(); }
 };
 
-Jsmn::Object parse_json(char const* txt) {
-	auto is = std::istringstream(txt);
-	auto rv = Jsmn::Object();
-	is >> rv;
-	return rv;
-}
-
 class DummyRpc {
 private:
 	S::Bus& bus;
@@ -183,7 +176,7 @@ private:
 	Ev::Io<void> respond(void* requester, char const* res) {
 		return bus.raise(Boss::Msg::ResponseRpcCommand{
 			requester, true,
-			parse_json(res),
+			Jsmn::Object::parse_json(res),
 			""
 		});
 	}
@@ -341,7 +334,7 @@ int main() {
 		assert(deferrer);
 
 		/* Raise the ListpeersResult.  */
-		auto res = parse_json(listpeers_result);
+		auto res = Jsmn::Object::parse_json(listpeers_result);
 		auto peers = res["peers"];
 		return bus.raise(Boss::Msg::ListpeersResult{
 				std::move(Boss::Mod::convert_legacy_listpeers(peers)), true

--- a/tests/boss/test_recentearnings.cpp
+++ b/tests/boss/test_recentearnings.cpp
@@ -1,0 +1,213 @@
+#undef NDEBUG
+
+#include"Boss/Mod/EarningsTracker.hpp"
+#include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/ForwardFee.hpp"
+#include"Boss/Msg/RequestMoveFunds.hpp"
+#include"Boss/Msg/ResponseMoveFunds.hpp"
+#include"Boss/Msg/CommandResponse.hpp"
+#include"Boss/Msg/CommandRequest.hpp"
+#include"Ev/start.hpp"
+#include"Jsmn/Object.hpp"
+#include"Jsmn/Parser.hpp"
+#include"Json/Out.hpp"
+#include"Ln/NodeId.hpp"
+#include"S/Bus.hpp"
+#include"Sqlite3.hpp"
+
+#include <cassert>
+#include<iostream>
+#include<sstream>
+
+namespace {
+auto const A = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000001");
+auto const B = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000002");
+auto const C = Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000003");
+}
+
+double mock_now = 0.0;
+double mock_get_now() {
+	return mock_now;
+}
+
+Ev::Io<void> raiseForwardFeeLoop(S::Bus& bus, int count) {
+	// Creates a series of forwards, one per hour
+	if (count == 0) {
+		return Ev::lift();
+	}
+	return bus.raise(Boss::Msg::ForwardFee{
+			A,              	// in_id
+			B,              	// out_id
+			Ln::Amount::sat(1),	// fee
+			1.0             	// resolution_time
+		})
+		.then([&, count]() {
+			mock_now += 60 * 60;
+			return raiseForwardFeeLoop(bus, count - 1);
+		});
+}
+
+Ev::Io<void> raiseMoveFundsLoop(S::Bus& bus, int count) {
+	if (count == 0) {
+		return Ev::lift();
+	}
+	return bus.raise(
+		Boss::Msg::RequestMoveFunds{
+			nullptr,        	// requester (match ResponseMoveFunds)
+			C,              	// source
+			B,              	// destination
+			Ln::Amount::sat(1000),  // amount
+			Ln::Amount::sat(3)      // fee_budget
+		})
+		.then([&bus]() {
+			return bus.raise(
+				Boss::Msg::ResponseMoveFunds{
+					nullptr,        	// requester (see RequestMoveFunds)
+					Ln::Amount::sat(1000),  // amount_moved
+					Ln::Amount::sat(2)      // fee_spent
+				});
+		})
+		.then([&bus, count]() {
+			mock_now += 24 * 60 * 60; // advance one day
+			return raiseMoveFundsLoop(bus, count - 1);
+		});
+}
+
+int main() {
+	auto bus = S::Bus();
+
+	/* Module under test */
+	Boss::Mod::EarningsTracker mut(bus, &mock_get_now);
+
+	auto db = Sqlite3::Db(":memory:");
+
+	auto req_id = std::uint64_t();
+	auto lastRsp = Boss::Msg::CommandResponse{};
+	auto rsp = false;
+	bus.subscribe<Boss::Msg::CommandResponse>([&](Boss::Msg::CommandResponse const& m) {
+		lastRsp = m;
+		rsp = true;
+		return Ev::yield();
+	});
+
+
+	auto code = Ev::lift().then([&]() {
+		return bus.raise(Boss::Msg::DbResource{ db });
+	}).then([&]() {
+		++req_id;
+		return bus.raise(Boss::Msg::CommandRequest{
+				"clboss-recent-earnings",
+				Jsmn::Object(),
+				Ln::CommandId::left(req_id)
+			});
+	}).then([&]() {
+		// With no fees should see an empty result collection
+		auto result = Jsmn::Object::parse_json(lastRsp.response.output().c_str());
+		assert(result["recent"] == Jsmn::Object::parse_json(R"JSON(
+				{}
+                                )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		// Insert 2 months of one fee per hour
+		mock_now = 1722902400; // stroke of midnight
+		return raiseForwardFeeLoop(bus, 24 * 60);
+	}).then([&]() {
+		// Rewind 1 week and add 7 days of one rebalance per day
+		mock_now -= (7 * 24 * 60 * 60);
+		return raiseMoveFundsLoop(bus, 7);
+	}).then([&]() {
+		// Default report should include 14 days
+		++req_id;
+		return bus.raise(Boss::Msg::CommandRequest{
+				"clboss-recent-earnings",
+				Jsmn::Object(),
+				Ln::CommandId::left(req_id)
+			});
+	}).then([&]() {
+		// std::cerr << lastRsp.response.output() << std::endl;
+		assert(rsp);
+		assert(lastRsp.id == Ln::CommandId::left(req_id));
+		auto result = Jsmn::Object::parse_json(lastRsp.response.output().c_str());
+		assert(result["recent"] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "020000000000000000000000000000000000000000000000000000000000000001": {
+			    "in_earnings": 336000,
+			    "in_expenditures": 0,
+			    "out_earnings": 0,
+			    "out_expenditures": 0
+			  },
+			  "020000000000000000000000000000000000000000000000000000000000000002": {
+			    "in_earnings": 0,
+			    "in_expenditures": 0,
+			    "out_earnings": 336000,
+			    "out_expenditures": 14000
+			  },
+			  "020000000000000000000000000000000000000000000000000000000000000003": {
+			    "in_earnings": 0,
+			    "in_expenditures": 14000,
+			    "out_earnings": 0,
+			    "out_expenditures": 0
+			  }
+			}
+                        )JSON"));
+		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "in_earnings": 336000,
+			  "in_expenditures": 14000,
+			  "out_earnings": 336000,
+			  "out_expenditures": 14000
+			}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		// Check a 30 day report
+		++req_id;
+		return bus.raise(Boss::Msg::CommandRequest{
+				"clboss-recent-earnings",
+				Jsmn::Object::parse_json(R"JSON( [30] )JSON"),
+				Ln::CommandId::left(req_id)
+			});
+	}).then([&]() {
+		// std::cerr << lastRsp.response.output() << std::endl;
+		assert(rsp);
+		assert(lastRsp.id == Ln::CommandId::left(req_id));
+		auto result = Jsmn::Object::parse_json(lastRsp.response.output().c_str());
+		// The expenditures stay the same because they are entirely in the last
+		// week but the earnings increase.
+		assert(result["recent"] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "020000000000000000000000000000000000000000000000000000000000000001": {
+			    "in_earnings": 720000,
+			    "in_expenditures": 0,
+			    "out_earnings": 0,
+			    "out_expenditures": 0
+			  },
+			  "020000000000000000000000000000000000000000000000000000000000000002": {
+			    "in_earnings": 0,
+			    "in_expenditures": 0,
+			    "out_earnings": 720000,
+			    "out_expenditures": 14000
+			  },
+			  "020000000000000000000000000000000000000000000000000000000000000003": {
+			    "in_earnings": 0,
+			    "in_expenditures": 14000,
+			    "out_earnings": 0,
+			    "out_expenditures": 0
+			  }
+			}
+                        )JSON"));
+		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "in_earnings": 720000,
+			  "in_expenditures": 14000,
+			  "out_earnings": 720000,
+			  "out_expenditures": 14000
+			}
+                        )JSON"));
+		return Ev::lift();
+	}).then([&]() {
+		return Ev::lift(0);
+	});
+
+	return Ev::start(std::move(code));
+}

--- a/tests/jsmn/test_equality.cpp
+++ b/tests/jsmn/test_equality.cpp
@@ -1,0 +1,81 @@
+#undef NDEBUG
+#include "Jsmn/Object.hpp"
+#include <cassert>
+#include <iostream>
+
+void test_null_equality() {
+    auto json_null1 = Jsmn::Object::parse_json(R"JSON({ "x": null })JSON");
+    auto json_null2 = Jsmn::Object::parse_json(R"JSON({ "x": null })JSON");
+    assert(json_null1 == json_null2);
+
+    auto json_non_null = Jsmn::Object::parse_json(R"JSON({ "x": 1 })JSON");
+    assert(json_null1 != json_non_null);
+}
+
+void test_boolean_equality() {
+    auto json_true1 = Jsmn::Object::parse_json(R"JSON({ "x": true })JSON");
+    auto json_true2 = Jsmn::Object::parse_json(R"JSON({ "x": true })JSON");
+    assert(json_true1 == json_true2);
+
+    auto json_false1 = Jsmn::Object::parse_json(R"JSON({ "x": false })JSON");
+    auto json_false2 = Jsmn::Object::parse_json(R"JSON({ "x": false })JSON");
+    assert(json_false1 == json_false2);
+
+    assert(json_true1 != json_false1);
+}
+
+void test_string_equality() {
+    auto json_str1 = Jsmn::Object::parse_json(R"JSON({ "x": "hello" })JSON");
+    auto json_str2 = Jsmn::Object::parse_json(R"JSON({ "x": "hello" })JSON");
+    assert(json_str1 == json_str2);
+
+    auto json_str3 = Jsmn::Object::parse_json(R"JSON({ "x": "world" })JSON");
+    assert(json_str1 != json_str3);
+}
+
+void test_number_equality() {
+    auto json_num1 = Jsmn::Object::parse_json(R"JSON({ "x": 42 })JSON");
+    auto json_num2 = Jsmn::Object::parse_json(R"JSON({ "x": 42 })JSON");
+    assert(json_num1 == json_num2);
+
+    auto json_num3 = Jsmn::Object::parse_json(R"JSON({ "x": 3.14 })JSON");
+    assert(json_num1 != json_num3);
+}
+
+void test_object_equality() {
+    auto json_obj1 = Jsmn::Object::parse_json(R"JSON({ "a": 1, "b": 2 })JSON");
+    auto json_obj2 = Jsmn::Object::parse_json(R"JSON({ "b": 2, "a": 1 })JSON");
+    assert(json_obj1 == json_obj2);
+
+    auto json_obj3 = Jsmn::Object::parse_json(R"JSON({ "a": 1, "b": 3 })JSON");
+    assert(json_obj1 != json_obj3);
+}
+
+void test_array_equality() {
+    auto json_arr1 = Jsmn::Object::parse_json(R"JSON([1, 2, 3])JSON");
+    auto json_arr2 = Jsmn::Object::parse_json(R"JSON([1, 2, 3])JSON");
+    assert(json_arr1 == json_arr2);
+
+    auto json_arr3 = Jsmn::Object::parse_json(R"JSON([3, 2, 1])JSON");
+    assert(json_arr1 != json_arr3);
+}
+
+void test_nested_structure_equality() {
+    auto json_nested1 = Jsmn::Object::parse_json(R"JSON({ "x": [ { "a": 1 }, { "b": 2 } ] })JSON");
+    auto json_nested2 = Jsmn::Object::parse_json(R"JSON({ "x": [ { "a": 1 }, { "b": 2 } ] })JSON");
+    assert(json_nested1 == json_nested2);
+
+    auto json_nested3 = Jsmn::Object::parse_json(R"JSON({ "x": [ { "b": 2 }, { "a": 1 } ] })JSON");
+    assert(json_nested1 != json_nested3);
+}
+
+int main() {
+    test_null_equality();
+    test_boolean_equality();
+    test_string_equality();
+    test_number_equality();
+    test_object_equality();
+    test_array_equality();
+    test_nested_structure_equality();
+    return 0;
+}


### PR DESCRIPTION
Addresses #227 

**IMPORTANT - This PR makes a schema change and migrates data!**

## Abstract

This PR modifies the `EarningsTracker` schema to hold data in "buckets", one per day.  This PR only modifies the collection and storage,  the strategies and existing status continue to use earnings data from all time for now.

## Motivation

As described in #227 there are several shortcomings w/ the current storage of `EarningsTracker` data:
1. Ancient data can dilute/overwhelm current data
2. Users would like income/expense reports for specific periods of time (especially recent periods)
3. The data doesn't "heal" as bugs are fixed and strategies are improved.

This PR enables time-based data earnings collection, future PR's should investigate modifying the strategies and reports to take advantage of the ability to filter by time range.

## Specification

This PR updates the `EarningsTracker` table to have a "time bucket" column.  The timestamps of incoming fee and balance events are quantized to a time bucket, currently one day.

The existing strategies and reports use the sql `SUM` to return the same answers that they would with the current schema.

The time and nodeid columns are indexed for efficient operations.

```
			CREATE TABLE IF NOT EXISTS EarningsTracker
			     ( node TEXT NOT NULL
			     , time_bucket REAL NOT NULL
			     , in_earnings INTEGER NOT NULL
			     , in_expenditures INTEGER NOT NULL
			     , out_earnings INTEGER NOT NULL
			     , out_expenditures INTEGER NOT NULL
			     , PRIMARY KEY (node, time_bucket)
			     );
			CREATE INDEX IF NOT EXISTS
			    idx_earnings_tracker_node_time ON EarningsTracker (node, time_bucket);
			CREATE INDEX IF NOT EXISTS
			    idx_earnings_tracker_time_node ON EarningsTracker (time_bucket, node);
```

Existing legacy data is migrated into the table with a time bucket value of 0.  This allows it to be considered and used but eventually be aged out.

Two new CLI commands are added to allow inspecting the new data:
- **`clboss-recent-earnings`**:
  - **Purpose**: Returns a data structure equivalent to the
    `offchain_earnings_tracker` collection in `clboss-status`, but
    only includes recent earnings and expenditures.
  - **Arguments**:
    - `days` (optional): Specifies the number of days to include in
      the report. Defaults to a fortnight (14 days) if not provided.

- **`clboss-earnings-history`**:
  - **Purpose**: Provides a daily breakdown of earnings and expenditures.
  - **Arguments**:
    - `nodeid` (optional): Limits the history to a particular node if
      provided. Without this argument, the values are accumulated
      across all peers.
  - **Output**: 
    - The history consists of an array of records showing the earnings
      and expenditures for each day.
    - The history includes an initial record with a time value of 0,
      which contains any legacy earnings and expenditures collected by
      CLBOSS before daily tracking was implemented.

