### PR TITLE
contrib: Improve clboss-routing-stats

### DIFF
--- a/contrib/clboss-routing-stats
+++ b/contrib/clboss-routing-stats
@@ -39,17 +39,30 @@ def pad_string(s, width):
     pad = width - wcswidth(s)
     return s + ' ' * pad
 
+import argparse
+
 def main():
     parser = argparse.ArgumentParser(description="Run lightning-cli with specified network")
-    parser.add_argument('--testnet', action='store_true', help='Run on testnet')
+
     parser.add_argument('--mainnet', action='store_true', help='Run on mainnet')
+    parser.add_argument('--testnet', action='store_true', help='Run on testnet')
+    parser.add_argument('--signet', action='store_true', help='Run on signet')
+    parser.add_argument('--regtest', action='store_true', help='Run on regtest')
+    parser.add_argument('--network', help='Set the network explicitly')
 
     args = parser.parse_args()
 
-    if args.testnet:
-        network_option = '--testnet'
+    # Reconcile network option
+    if args.network:
+        network_option = f'--network={args.network}'
+    elif args.testnet:
+        network_option = '--network=testnet'
+    elif args.signet:
+        network_option = '--network=signet'
+    elif args.regtest:
+        network_option = '--network=regtest'
     else:
-        network_option = '--mainnet'  # Default to mainnet if no option is specified
+        network_option = '--network=bitcoin'	# lightning-cli wants "bitcoin" for mainnet
 
     # Run listpeerchannels command
     listpeerchannels_data = run_lightning_cli_command(network_option, 'listpeerchannels')

--- a/contrib/clboss-routing-stats
+++ b/contrib/clboss-routing-stats
@@ -14,6 +14,7 @@ import argparse
 import json
 from tabulate import tabulate
 from wcwidth import wcswidth
+from clboss.alias_cache import lookup_alias
 
 def run_lightning_cli_command(network_option, command, *args):
     try:
@@ -85,15 +86,9 @@ def main():
                     "success_per_day": 0
                 }
 
-    # Run listnodes command for each unique peer_id and update alias
     for peer_id in peers.keys():
-        listnodes_data = run_lightning_cli_command(network_option, 'listnodes', peer_id)
-        if listnodes_data:
-            nodes = listnodes_data.get("nodes", [])
-            for node in nodes:
-                alias = node.get("alias")
-                if peer_id in peers:
-                    peers[peer_id]["alias"] = alias
+        alias = lookup_alias(run_lightning_cli_command, network_option, peer_id)
+        peers[peer_id]["alias"] = alias
 
     # Run clboss-status command and capture the output
     clboss_status_data = run_lightning_cli_command(network_option, 'clboss-status')

--- a/contrib/clboss-routing-stats
+++ b/contrib/clboss-routing-stats
@@ -135,12 +135,14 @@ def main():
         peer = peers[peer_id]
         income_minus_expenditures, success_per_day = calculate_peer_score(peer)
         alias = pad_string(peer["alias"], max_alias_length)
+        opener = "L" if channels[short_channel_id]["opener"] == "local" else "R"
         to_us_msat = f"{channels[short_channel_id]['to_us_msat']:,}"  # With commas
         income_minus_expenditures_formatted = f"{income_minus_expenditures:,}"  # With commas
         spd_formatted = f"x{success_per_day:4.1f}"  # Prefix w/ 'x', strip later, preserves padding
         table_data.append([
             alias,
             short_channel_id,
+            opener,
             to_us_msat,
             peer["age"] // 86400,  # Convert age from seconds to days
             income_minus_expenditures_formatted,
@@ -150,9 +152,26 @@ def main():
 
     # Print the table without grid
     table_str = tabulate(table_data,
-                         headers=["Alias", "SCID", "to us", "Age", "Net msat", "SPD", "PeerID"],
+                         headers=[
+                             "Alias",
+                             "SCID",
+                             "O",
+                             "to us",
+                             "Age",
+                             "Net msat",
+                             "SPD",
+                             "PeerID"
+                         ],
                          tablefmt="plain", stralign="left", numalign="right",
-                         colalign=("left", "left", "right", "right", "right", "left", "left"))
+                         colalign=(
+                             "left",
+                             "left",
+                             "left",
+                             "right",
+                             "right",
+                             "right",
+                             "left",
+                             "left"))
 
     # Remove the "x" prefix from SPD values in the final output
     table_str = table_str.replace(" x", " ")


### PR DESCRIPTION
Includes:
- use the alias cache developed of the other scripts
- generalize network param handling (`--network, --testnet, --signet, ...`)
- add an opener column to show who opened each channel