### PR TITLE
add explicit github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Create Release Tarballs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Set up build tools
+        run: sudo apt-get install -y build-essential autoconf automake libtool zip
+
+      - name: Configure the project
+        run: ./configure
+
+      - name: Build the project
+        run: make
+
+      - name: Create .tar.gz source tarball
+        run: make dist
+
+      - name: Create .zip source tarball
+        run: make dist-zip
+
+      - name: List generated files
+        run: ls -lah
+
+      - name: Upload .tar.gz release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./clboss-*.tar.gz
+          asset_name: clboss-${{ github.event.release.tag_name }}.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload .zip release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./clboss-*.zip
+          asset_name: clboss-${{ github.event.release.tag_name }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This was necessary because the default tarball preparation did not include commit_hash.h