### PR TITLE
Add contrib-shell.nix to allow running contrib scripts in nix

### DIFF
--- a/contrib-shell.nix
+++ b/contrib-shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz";
+}) {} }:
+
+let
+  poetry2nix = import (builtins.fetchGit {
+    url = "https://github.com/nix-community/poetry2nix";
+  }) { inherit pkgs; };
+in
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.poetry
+    (poetry2nix.mkPoetryEnv {
+      projectDir = ./contrib;
+    })
+  ];
+}
+

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -2,19 +2,47 @@
 
 ## Installing
 
+There are two ways to install the requirements:
+- poetry
+- nix
+
+### Poetry
+There are two ways to install poetry:
+- pipx
+- official installer
+
+#### Pipx
+
 ```
 # Install pipx
 sudo apt update
 sudo apt install pipx
+pipx install poetry
+```
 
+#### [Or, click here for the official installer](https://python-poetry.org/docs/#installing-with-the-official-installer)
+
+Once poetry is installed, install the Python dependencies:
+
+```
 # The following commands need to be run as the user who will be running
 # the clboss utility commands (connecting to the CLN RPC port)
-
-# Install poetry: https://python-poetry.org/docs/#installing-with-the-official-installer
 
 # Install clboss contrib utilities
 poetry shell
 poetry install
+```
+
+### Nix
+If you have nix, you can just do, from the project root:
+```
+nix-shell contrib-shell.nix
+```
+
+Then before running the commands below, be sure to do:
+
+```
+cd contrib/
 ```
 
 ## Running


### PR DESCRIPTION
Just do `nix-shell contrib-shell.nix` then run any of the python scripts in contrib/