### PR TITLE
contrib: add --lightning-dir option

### DIFF
--- a/contrib/clboss-earnings-history
+++ b/contrib/clboss-earnings-history
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import subprocess
 import argparse
 import json
@@ -7,9 +8,12 @@ from datetime import datetime
 from tabulate import tabulate
 from clboss.alias_cache import lookup_alias, is_nodeid, lookup_nodeid_by_alias
 
-def run_lightning_cli_command(network_option, command, *args):
+def run_lightning_cli_command(lightning_dir, network_option, command, *args):
     try:
-        result = subprocess.run(['lightning-cli', network_option, command, *args],
+        command = ['lightning-cli', network_option, command, *args]
+        if lightning_dir:
+            command = command[:2] + [f'--lightning-dir={lightning_dir}'] + command[2:]
+        result = subprocess.run(command,
                                 capture_output=True,
                                 text=True,
                                 check=True)
@@ -37,6 +41,8 @@ def main():
     parser.add_argument('nodeid_or_alias', nargs='?',
                         help='The node ID (or alias) to pass to clboss-earnings-history (optional)')
 
+    parser.add_argument('--lightning-dir', help='lightning data location')
+
     args = parser.parse_args()
 
     # Reconcile network option
@@ -51,22 +57,28 @@ def main():
     else:
         network_option = '--network=bitcoin'	# lightning-cli wants "bitcoin" for mainnet
 
+    if args.lightning_dir:
+        lightning_dir = args.lightning_dir
+        assert os.path.isdir(lightning_dir), f'"{lightning_dir}" is not a valid directory'
+    else:
+        lightning_dir = None
+
     alias = None
     nodeid = None
     if args.nodeid_or_alias:
         # Determine if input is a nodeid or alias
         if is_nodeid(args.nodeid_or_alias):  # Check if it's a node ID
             nodeid = args.nodeid_or_alias
-            alias = lookup_alias(run_lightning_cli_command, network_option, nodeid)
+            alias = lookup_alias(run_lightning_cli_command, lightning_dir, network_option, nodeid)
         else:  # It's an alias, so look it up
             alias = args.nodeid_or_alias
-            nodeid = lookup_nodeid_by_alias(run_lightning_cli_command, network_option, alias)
+            nodeid = lookup_nodeid_by_alias(run_lightning_cli_command, lightning_dir, network_option, alias)
             if not nodeid:
                 print(f"Error: Alias '{alias}' not found.")
                 return
 
     earnings_data = run_lightning_cli_command(
-        network_option, 'clboss-earnings-history', nodeid or "")
+        lightning_dir, network_option, 'clboss-earnings-history', nodeid or "")
 
     # Initialize totals
     total_net_earnings = 0

--- a/contrib/clboss-recent-earnings
+++ b/contrib/clboss-recent-earnings
@@ -7,9 +7,12 @@ import json
 from tabulate import tabulate
 from clboss.alias_cache import lookup_alias
 
-def run_lightning_cli_command(network_option, command, *args):
+def run_lightning_cli_command(lightning_dir, network_option, command, *args):
     try:
-        result = subprocess.run(['lightning-cli', network_option, command, *args], capture_output=True, text=True, check=True)
+        command = ['lightning-cli', network_option, command, *args]
+        if lightning_dir:
+            command = command[:2] + [f'--lightning-dir={lightning_dir}'] + command[2:]
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
     except subprocess.CalledProcessError as e:
         print(f"Command '{command}' failed with error: {e}")
@@ -34,7 +37,7 @@ headers = [
     "Net Earn",
 ]
 
-def calculate_net_earnings(data, network_option):
+def calculate_net_earnings(data, lightning_dir, network_option):
     rows = []
 
     # Initialize totals
@@ -66,7 +69,7 @@ def calculate_net_earnings(data, network_option):
         ):
             continue
 
-        alias = lookup_alias(run_lightning_cli_command, network_option, node)
+        alias = lookup_alias(run_lightning_cli_command, lightning_dir, network_option, node)
 
         in_forwarded_rate = (in_earnings / in_forwarded) * 1_000_000 if in_forwarded != 0 else 0
         in_rebalance_rate = (in_expenditures / in_rebalanced) * 1_000_000 if in_rebalanced != 0 else 0
@@ -144,6 +147,8 @@ def main():
 
     parser.add_argument('days', nargs='?', help='The number of days to pass to clboss-earnings-history (optional)')
 
+    parser.add_argument('--lightning-dir', help='lightning data location')
+
     args = parser.parse_args()
 
     # Reconcile network option
@@ -158,13 +163,19 @@ def main():
     else:
         network_option = '--network=bitcoin'	# lightning-cli wants "bitcoin" for mainnet
 
-    if args.days:
-        earnings_data = run_lightning_cli_command(network_option, 'clboss-recent-earnings', str(args.days))
+    if args.lightning_dir:
+        lightning_dir = args.lightning_dir
+        assert os.path.isdir(lightning_dir), f'"{lightning_dir}" is not a valid directory'
     else:
-        earnings_data = run_lightning_cli_command(network_option, 'clboss-recent-earnings')
+        lightning_dir = None
+
+    if args.days:
+        earnings_data = run_lightning_cli_command(lightning_dir, network_option, 'clboss-recent-earnings', str(args.days))
+    else:
+        earnings_data = run_lightning_cli_command(lightning_dir, network_option, 'clboss-recent-earnings')
 
     if earnings_data:
-        rows = calculate_net_earnings(earnings_data, network_option)
+        rows = calculate_net_earnings(earnings_data, lightning_dir, network_option)
         print(tabulate(rows, headers=headers, tablefmt="pretty", stralign="right", numalign="right"))
 
 if __name__ == "__main__":

--- a/contrib/clboss-routing-stats
+++ b/contrib/clboss-routing-stats
@@ -9,6 +9,7 @@
 #
 # The channels at the top of the list are good, the ones at the bottom are bad.
 
+import os
 import subprocess
 import argparse
 import json
@@ -16,9 +17,12 @@ from tabulate import tabulate
 from wcwidth import wcswidth
 from clboss.alias_cache import lookup_alias
 
-def run_lightning_cli_command(network_option, command, *args):
+def run_lightning_cli_command(lightning_dir, network_option, command, *args):
     try:
-        result = subprocess.run(['lightning-cli', network_option, command, *args], capture_output=True, text=True, check=True)
+        command = ['lightning-cli', network_option, command, *args]
+        if lightning_dir:
+            command = command[:2] + [f'--lightning-dir={lightning_dir}'] + command[2:]
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
     except subprocess.CalledProcessError as e:
         print(f"Command '{command}' failed with error: {e}")
@@ -49,6 +53,7 @@ def main():
     parser.add_argument('--signet', action='store_true', help='Run on signet')
     parser.add_argument('--regtest', action='store_true', help='Run on regtest')
     parser.add_argument('--network', help='Set the network explicitly')
+    parser.add_argument('--lightning-dir', help='lightning data location')
 
     args = parser.parse_args()
 
@@ -64,8 +69,14 @@ def main():
     else:
         network_option = '--network=bitcoin'	# lightning-cli wants "bitcoin" for mainnet
 
+    if args.lightning_dir:
+        lightning_dir = args.lightning_dir
+        assert os.path.isdir(lightning_dir), f'"{lightning_dir}" is not a valid directory'
+    else:
+        lightning_dir = None
+
     # Run listpeerchannels command
-    listpeerchannels_data = run_lightning_cli_command(network_option, 'listpeerchannels')
+    listpeerchannels_data = run_lightning_cli_command(lightning_dir, network_option, 'listpeerchannels')
     if not listpeerchannels_data:
         return
 
@@ -100,11 +111,11 @@ def main():
                 }
 
     for peer_id in peers.keys():
-        alias = lookup_alias(run_lightning_cli_command, network_option, peer_id)
+        alias = lookup_alias(run_lightning_cli_command, lightning_dir, network_option, peer_id)
         peers[peer_id]["alias"] = alias
 
     # Run clboss-status command and capture the output
-    clboss_status_data = run_lightning_cli_command(network_option, 'clboss-status')
+    clboss_status_data = run_lightning_cli_command(lightning_dir, network_option, 'clboss-status')
     if clboss_status_data:
         offchain_earnings_tracker = clboss_status_data.get("offchain_earnings_tracker", {})
         peer_metrics = clboss_status_data.get("peer_metrics", {})

--- a/contrib/clboss/alias_cache.py
+++ b/contrib/clboss/alias_cache.py
@@ -19,7 +19,7 @@ def save_cache(cache):
     with open(CACHE_FILE, 'w') as f:
         json.dump(cache, f)
 
-def lookup_alias(run_lightning_cli_command, network_option, peer_id):
+def lookup_alias(run_lightning_cli_command, lightning_dir, network_option, peer_id):
     # Load the cache
     cache = load_cache()
 
@@ -29,7 +29,7 @@ def lookup_alias(run_lightning_cli_command, network_option, peer_id):
 
     # Perform the lookup
     alias = peer_id  # Default to peer_id if alias not found
-    listnodes_data = run_lightning_cli_command(network_option, 'listnodes', peer_id)
+    listnodes_data = run_lightning_cli_command(lightning_dir, network_option, 'listnodes', peer_id)
     if listnodes_data:
         nodes = listnodes_data.get("nodes", [])
         for node in nodes:
@@ -41,7 +41,7 @@ def lookup_alias(run_lightning_cli_command, network_option, peer_id):
 
     return alias
 
-def lookup_nodeid_by_alias(run_lightning_cli_command, network_option, alias):
+def lookup_nodeid_by_alias(run_lightning_cli_command, lightning_dir, network_option, alias):
     # Load the cache
     cache = load_cache()
 
@@ -51,7 +51,7 @@ def lookup_nodeid_by_alias(run_lightning_cli_command, network_option, alias):
             return peer_id
 
     # Perform exhaustive search using `listnodes`
-    listnodes_data = run_lightning_cli_command(network_option, 'listnodes')
+    listnodes_data = run_lightning_cli_command(lightning_dir, network_option, 'listnodes')
     if listnodes_data:
         nodes = listnodes_data.get("nodes", [])
         for node in nodes:


### PR DESCRIPTION
This adds a custom lightning directory option to clboss-earnings-history, clboss-recent-earnings, and clboss-routing-stats for users with non-default configurations.  I probably should have just symlinked it, but I think it can be handy to have these options be explicit.