### PR TITLE
boltz: Validate initial claim destination address

### DIFF
--- a/Boss/Mod/SwapManager.cpp
+++ b/Boss/Mod/SwapManager.cpp
@@ -280,6 +280,8 @@ private:
 			/* First, try to get an address from the addrcache.  */
 			auto check = tx.query(R"QRY(
 			SELECT id, address FROM "SwapManager_addrcache"
+                         WHERE address IS NOT NULL
+                          AND address <> ''
 			 ORDER BY id
 			 LIMIT 1
 			     ;
@@ -626,12 +628,14 @@ private:
 		auto address = std::string();
 		for (auto& r : fetch)
 			address = r.get<std::string>(0);
-		tx.query(R"QRY(
-		INSERT INTO "SwapManager_addrcache"
-		VALUES(NULL, :address);
-		)QRY")
-			.bind(":address", address)
-			.execute();
+		if (!address.empty()) {
+			tx.query(R"QRY(
+		        INSERT INTO "SwapManager_addrcache"
+		        VALUES(NULL, :address);
+		        )QRY")
+				.bind(":address", address)
+				.execute();
+		}
 
 		/* Delete the swap itself.  */
 		tx.query(R"QRY(

--- a/Boss/Mod/SwapManager.cpp
+++ b/Boss/Mod/SwapManager.cpp
@@ -191,6 +191,12 @@ private:
 			     ( payment_hash TEXT UNIQUE
 			     , amount_sent INTEGER NOT NULL
 			     );
+
+			-- Sanity check to remove erroneous blank addresses
+			-- from the address cache.
+			DELETE FROM SwapManager_addrcache
+			 WHERE address IS NULL
+			  OR address = '';
 			)QRY");
 			tx.commit();
 


### PR DESCRIPTION
Tries to prevent the following error in the logs:

```
Unhandled exception in concurrent task!
lightningd[181525]: Bitcoin::UnknownAddrType
```

In my case, the database table `BoltzServiceFactory_rsub` has four entries, all of which contain empty strings for the `destinationAddress` field. These blank fields are predictably un-parsable as Bitcoin addresses.

Without the validation, the empty addresses get passed in to building an initial claim tx [here](https://github.com/ZmnSCPxj/clboss/blob/88ba9f22feca12073685979ccbca51093d47f9a9/Boltz/Detail/ClaimTxHandler.cpp#L177) and an error is thrown [here](https://github.com/ZmnSCPxj/clboss/blob/88ba9f22feca12073685979ccbca51093d47f9a9/Boltz/Detail/initial_claim_tx.cpp#L67).

*I have next to 0 experience with `clboss` code and am no C++ expert by any means. Submitting this as a PoC / draft PR for a quick glance and if it's on the right track, I'll attempt to finish the address parsing validation.*