### PR TITLE
build: Fix building clboss as a git submodule

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -679,8 +679,10 @@ create-tarball: create-tarball.in Makefile
 BUILT_SOURCES = commit_hash.h
 
 commit_hash.h: FORCE
-	@if test -e $(srcdir)/.git/logs/HEAD; then \
-		if [ ! -f $(srcdir)/commit_hash.h ] || [ $(srcdir)/.git/logs/HEAD -nt $(srcdir)/commit_hash.h ]; then \
+	@if git -C $(srcdir) rev-parse --is-inside-work-tree > /dev/null 2>&1; then \
+		CURRENT_HASH="$$(git -C $(srcdir) rev-parse HEAD)"; \
+		if [ ! -f $(srcdir)/commit_hash.h ] || \
+		   [ "$$(grep -oE '[0-9a-f]{40}' $(srcdir)/commit_hash.h)" != "$$CURRENT_HASH" ]; then \
 			echo "Regenerating $(srcdir)/commit_hash.h..."; \
 			$(SHELL) $(srcdir)/generate_commit_hash.sh; \
 		else \


### PR DESCRIPTION
When clboss is a git submodule, the current Makefile fails because it assumes that, because the `$(srcdir)/.git/logs/HEAD` file does not exist, we must be inside the release zip and therefore already have the commit_hash.h file present.

Here we update the Makefile to detect the case where clboss is a git submodule (by detecting that `.git` is a regular file and not a directory), and run generate_commit_hash.sh in that case.

Fixes #247 