### PR TITLE
Add configurable max rebalance fee in ppm

### DIFF
--- a/Boss/Mod/EarningsRebalancer.cpp
+++ b/Boss/Mod/EarningsRebalancer.cpp
@@ -47,7 +47,7 @@ auto constexpr src_gap_percent = double(2.5);
 /* Target to get to the destination.  */
 auto constexpr dst_target_percent = double(75.0);
 /* Maximum fee for a single rebalance in parts per million.  */
-auto constexpr default_max_fee_ppm = std::uint32_t(5000);
+auto constexpr default_max_fee_ppm = std::uint32_t(1000);
 
 /* The top percentile (based on earnings - expenditures) that we are going to
  * rebalance.  */

--- a/Boss/Mod/EarningsRebalancer.cpp
+++ b/Boss/Mod/EarningsRebalancer.cpp
@@ -32,20 +32,20 @@
 namespace {
 
 /* If we call dist on the random engine, and it comes up 1, we
- * trigger earnings rebalancer.  */
+ * trigger earnings rebalancer.	 */
 auto dist = std::uniform_int_distribution<std::size_t>(
 	1, 2
 );
 
 /* If the spendable amount is below this percent of the channel
- * total, trigger rebalancing *to* the channel.   */
+ * total, trigger rebalancing *to* the channel.	  */
 auto constexpr max_spendable_percent = double(25.0);
 /* Gap to prevent sources from becoming equal to the max_spendable_percent.  */
 auto constexpr src_gap_percent = double(2.5);
 /* Target to get to the destination.  */
 auto constexpr dst_target_percent = double(75.0);
 /* Once we have computed a desired amount to move, this limits how much we are
- * going to pay as fee.  */
+ * going to pay as fee.	 */
 auto constexpr maxfeepercent = double(0.5);
 
 /* The top percentile (based on earnings - expenditures) that we are going to
@@ -289,13 +289,13 @@ private:
 				     ;
 			});
 
-			/* Build up the action.  */
+			/* Build up the action.	 */
 			auto act = Ev::lift();
 			for (auto i = std::size_t(0); i < num_rebalance; ++i) {
 				auto s = sources[i];
 				auto d = destinations[i];
 
-				/* If the destination has negative out earnings, stop.  */
+				/* If the destination has negative out earnings, stop.	*/
 				auto const& ed = earnings[d];
 				auto dest_earnings = ed.out_net_earnings;
 				if (dest_earnings <= 0) {
@@ -310,7 +310,7 @@ private:
 							);
 					/* Since the vector is sorted from highest net
 					 * earnings to lowest, the rest of the vector can
-					 * be skipped.  */
+					 * be skipped.	*/
 					break;
 				}
 
@@ -321,7 +321,7 @@ private:
 
 				/* Determine how much money the source can spend
 				 * without going below max_spendable_percent and the
-				 * gap.  */
+				 * gap.	 */
 				auto const& bs = balances[s];
 				auto src_min_allowed = bs.total
 						     * ( max_spendable_percent
@@ -344,7 +344,7 @@ private:
 						dest_earnings
 					));
 					/* Also adjust the amount we are hoping to
-					 * transfer downwards.  */
+					 * transfer downwards.	*/
 					dest_needed = fee_budget * (100.0 / maxfeepercent);
 				}
 
@@ -356,7 +356,7 @@ private:
 						, Util::stringify(dest_needed).c_str()
 						, Util::stringify(d).c_str()
 						, Util::stringify(fee_budget).c_str()
-					        )
+						)
 				     + Boss::concurrent(bus.raise(Msg::RequestMoveFunds{
 						this, s, d, dest_needed, fee_budget
 				       }))

--- a/Boss/Mod/JitRebalancer.cpp
+++ b/Boss/Mod/JitRebalancer.cpp
@@ -13,6 +13,9 @@
 #include"Boss/Msg/ResponsePeerFromScid.hpp"
 #include"Boss/Msg/ProvideHtlcAcceptedDeferrer.hpp"
 #include"Boss/Msg/SolicitHtlcAcceptedDeferrer.hpp"
+#include"Boss/Msg/Manifestation.hpp"
+#include"Boss/Msg/ManifestOption.hpp"
+#include"Boss/Msg/Option.hpp"
 #include"Boss/concurrent.hpp"
 #include"Boss/log.hpp"
 #include"Boss/random_engine.hpp"
@@ -65,8 +68,8 @@ auto constexpr max_fee_percent = double(25.0);
  */
 auto const free_fee = Ln::Amount::sat(10);
 
-/* Maximum limit for costs of a *single* rebalance.  */
-auto constexpr max_rebalance_fee_percent = double(0.5);
+/* Maximum limit for costs of a *single* rebalance, in parts per million.  */
+auto constexpr default_max_rebalance_fee_ppm = std::uint32_t(5000);
 auto const min_rebalance_fee = Ln::Amount::sat(5);
 
 std::string stringify_cid(Ln::CommandId const& id) {
@@ -104,20 +107,43 @@ private:
 	MoveFundsRR move_funds_rr;
 	PeerFromScidRR peer_from_scid_rr;
 
-	ModG::RebalanceUnmanagerProxy unmanager;
+        ModG::RebalanceUnmanagerProxy unmanager;
+        std::uint32_t max_rebalance_fee_ppm;
 
-	void start() {
-		bus.subscribe<Msg::SolicitHtlcAcceptedDeferrer
-			     >([this
-			       ](Msg::SolicitHtlcAcceptedDeferrer const&) {
-			auto f = [this](Ln::HtlcAccepted::Request const& req) {
-				return htlc_accepted(req);
-			};
-			return bus.raise(Msg::ProvideHtlcAcceptedDeferrer{
-				std::move(f)
-			});
-		});
-	}
+        void start() {
+                max_rebalance_fee_ppm = default_max_rebalance_fee_ppm;
+
+                bus.subscribe<Msg::Manifestation
+                             >([this](Msg::Manifestation const&) {
+                        return bus.raise(Msg::ManifestOption{
+                                "clboss-max-rebalance-fee-ppm",
+                                Msg::OptionType_Int,
+                                Json::Out::direct(max_rebalance_fee_ppm),
+                                "Maximum fee in ppm for a single rebalance."
+                        });
+                });
+                bus.subscribe<Msg::Option
+                             >([this](Msg::Option const& o) {
+                        if (o.name != "clboss-max-rebalance-fee-ppm")
+                                return Ev::lift();
+			auto ppm = std::uint32_t(double(o.value));
+			max_rebalance_fee_ppm = ppm;
+                        return Boss::log( bus, Info,
+                                         "JitRebalancer: max fee set to %u ppm",
+                                         (unsigned)ppm );
+                });
+
+                bus.subscribe<Msg::SolicitHtlcAcceptedDeferrer
+                             >([this
+                               ](Msg::SolicitHtlcAcceptedDeferrer const&) {
+                        auto f = [this](Ln::HtlcAccepted::Request const& req) {
+                                return htlc_accepted(req);
+                        };
+                        return bus.raise(Msg::ProvideHtlcAcceptedDeferrer{
+                                std::move(f)
+                        });
+                });
+        }
 
 	Ev::Io<bool>
 	htlc_accepted(Ln::HtlcAccepted::Request const& req) {
@@ -175,14 +201,15 @@ private:
 	public:
 		Run() =delete;
 
-		Run(S::Bus& bus, Boss::ModG::RpcProxy& rpc
-		   , Ln::NodeId const& node
-		   , Ln::Amount amount
-		   , Ln::CommandId id
-		   , EarningsInfoRR& earnings_info_rr
-		   , MoveFundsRR& move_funds_rr
-		   , ModG::RebalanceUnmanagerProxy& unmanager
-		   );
+                Run(S::Bus& bus, Boss::ModG::RpcProxy& rpc
+                   , Ln::NodeId const& node
+                   , Ln::Amount amount
+                   , Ln::CommandId id
+                   , EarningsInfoRR& earnings_info_rr
+                   , MoveFundsRR& move_funds_rr
+                   , ModG::RebalanceUnmanagerProxy& unmanager
+                   , std::uint32_t& max_rebalance_fee_ppm
+                   );
 		Run(Run&&) =default;
 		Run(Run const&) =default;
 		~Run() =default;
@@ -196,10 +223,10 @@ private:
 		      , Ln::CommandId id
 		      ) {
 		return Ev::lift().then([this, node, amount, id]() {
-			auto r = Run( bus, rpc, node, amount, id
-				    , earnings_info_rr, move_funds_rr
-				    , unmanager
-				    );
+                        auto r = Run( bus, rpc, node, amount, id
+                                    , earnings_info_rr, move_funds_rr
+                                    , unmanager, max_rebalance_fee_ppm
+                                    );
 			return r.execute();
 		});
 	}
@@ -211,8 +238,8 @@ public:
 	      , earnings_info_rr(bus)
 	      , move_funds_rr(bus)
 	      , peer_from_scid_rr(bus)
-	      , unmanager(bus)
-	      { start(); }
+              , unmanager(bus)
+              { start(); }
 };
 
 /* Yes, what a messy name... */
@@ -242,7 +269,8 @@ private:
 	/* ReqResp to `Boss::Mod::FundsMover`.	*/
 	MoveFundsRR& move_funds_rr;
 	/* Unmanager proxy.  */
-	ModG::RebalanceUnmanagerProxy& unmanager;
+        ModG::RebalanceUnmanagerProxy& unmanager;
+        std::uint32_t& max_rebalance_fee_ppm;
 
 	std::set<Ln::NodeId> const* unmanaged;
 
@@ -418,10 +446,10 @@ private:
 					return Ev::lift();
 				});
 
-			auto max_rebalance_fee = to_move
-					       * ( max_rebalance_fee_percent
-						 / 100.0
-						 );
+                        auto max_rebalance_fee = to_move
+                                               * ( double(max_rebalance_fee_ppm)
+                                                   / 1000000.0
+                                                 );
 			if (max_rebalance_fee < min_rebalance_fee)
 				max_rebalance_fee = min_rebalance_fee;
 
@@ -501,20 +529,22 @@ private:
 	}
 
 public:
-	Impl( S::Bus& bus_
-	    , Boss::ModG::RpcProxy& rpc_
-	    , Ln::NodeId const& out_node_
-	    , Ln::Amount amount_
-	    , Ln::CommandId id_
-	    , EarningsInfoRR& earnings_info_rr_
-	    , MoveFundsRR& move_funds_rr_
-	    , ModG::RebalanceUnmanagerProxy& unmanager_
-	    ) : bus(bus_), rpc(rpc_)
-	      , out_node(out_node_), amount(amount_), id(id_)
-	      , earnings_info_rr(earnings_info_rr_)
-	      , move_funds_rr(move_funds_rr_)
-	      , unmanager(unmanager_)
-	      { }
+        Impl( S::Bus& bus_
+            , Boss::ModG::RpcProxy& rpc_
+            , Ln::NodeId const& out_node_
+            , Ln::Amount amount_
+            , Ln::CommandId id_
+            , EarningsInfoRR& earnings_info_rr_
+            , MoveFundsRR& move_funds_rr_
+            , ModG::RebalanceUnmanagerProxy& unmanager_
+            , std::uint32_t& max_rebalance_fee_ppm_
+            ) : bus(bus_), rpc(rpc_)
+              , out_node(out_node_), amount(amount_), id(id_)
+              , earnings_info_rr(earnings_info_rr_)
+              , move_funds_rr(move_funds_rr_)
+              , unmanager(unmanager_)
+              , max_rebalance_fee_ppm(max_rebalance_fee_ppm_)
+              { }
 
 	static
 	Ev::Io<void> execute(std::shared_ptr<Impl> self) {
@@ -540,13 +570,14 @@ JitRebalancer::Impl::Run::Run( S::Bus& bus
 			     , Ln::Amount amount
 			     , Ln::CommandId id
 			     , EarningsInfoRR& earnings_info_rr
-			     , MoveFundsRR& move_funds_rr
-			     , ModG::RebalanceUnmanagerProxy& unmanager
-			     )
-	: pimpl(std::make_shared<Impl>( bus, rpc, node, amount, id
-				      , earnings_info_rr, move_funds_rr
-				      , unmanager
-				      )) { }
+                             , MoveFundsRR& move_funds_rr
+                             , ModG::RebalanceUnmanagerProxy& unmanager
+                             , std::uint32_t& max_rebalance_fee_ppm
+                             )
+        : pimpl(std::make_shared<Impl>( bus, rpc, node, amount, id
+                                      , earnings_info_rr, move_funds_rr
+                                      , unmanager, max_rebalance_fee_ppm
+                                      )) { }
 Ev::Io<void> JitRebalancer::Impl::Run::execute() {
 	return Impl::execute(pimpl);
 }

--- a/Boss/Mod/JitRebalancer.cpp
+++ b/Boss/Mod/JitRebalancer.cpp
@@ -234,12 +234,12 @@ private:
 	std::map<Ln::NodeId, ChannelInfo> available;
 	/* How much should we add to the destination?  */
 	Ln::Amount to_move;
-	/* Up to how much to pay for *this* rebalance.  */
+	/* Up to how much to pay for *this* rebalance.	*/
 	Ln::Amount this_rebalance_fee;
 
 	/* ReqResp to `Boss::Mod::EarningsTracker`.  */
 	EarningsInfoRR& earnings_info_rr;
-	/* ReqResp to `Boss::Mod::FundsMover`.  */
+	/* ReqResp to `Boss::Mod::FundsMover`.	*/
 	MoveFundsRR& move_funds_rr;
 	/* Unmanager proxy.  */
 	ModG::RebalanceUnmanagerProxy& unmanager;
@@ -306,10 +306,10 @@ private:
 			return rpc.command("listpeerchannels", std::move(parms));
 		}).then([this](Jsmn::Object res) {
 			try {
-                                  // auto ps = res["peers"];
-                                  // for (auto p : ps) {
-                          	auto cs = res["channels"];
-                                for (auto c : cs) {
+				  // auto ps = res["peers"];
+				  // for (auto p : ps) {
+				auto cs = res["channels"];
+				for (auto c : cs) {
 					auto to_us = Ln::Amount::sat(0);
 					auto capacity = Ln::Amount::sat(0);
 					auto peer = Ln::NodeId(std::string(
@@ -336,7 +336,7 @@ private:
 					auto& av = available[peer];
 					av.to_us += to_us;
 					av.capacity += capacity;
-                                }
+				}
 			} catch (std::exception const& ex) {
 				return Boss::log( bus, Error
 						, "JitRebalancer: Unexpected "
@@ -395,7 +395,7 @@ private:
 		}).then([this]() {
 
 			/* Determine how much fee we can use for
-			 * rebalancing.  */
+			 * rebalancing.	 */
 			return get_earnings(out_node);
 		}).then([this](Earnings e) {
 			/* Total aggregated limit.  */
@@ -429,7 +429,7 @@ private:
 			if (this_rebalance_fee > max_rebalance_fee)
 				this_rebalance_fee = max_rebalance_fee;
 
-			/* Now select a source channel.  */
+			/* Now select a source channel.	 */
 			auto min_required = to_move
 					  + (this_rebalance_fee / 2.0)
 					  ;

--- a/Boss/Mod/JitRebalancer.cpp
+++ b/Boss/Mod/JitRebalancer.cpp
@@ -69,7 +69,7 @@ auto constexpr max_fee_percent = double(25.0);
 auto const free_fee = Ln::Amount::sat(10);
 
 /* Maximum limit for costs of a *single* rebalance, in parts per million.  */
-auto constexpr default_max_rebalance_fee_ppm = std::uint32_t(5000);
+auto constexpr default_max_rebalance_fee_ppm = std::uint32_t(1000);
 auto const min_rebalance_fee = Ln::Amount::sat(5);
 
 std::string stringify_cid(Ln::CommandId const& id) {

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ suffix, e.g.
 
 Limits the fee CLBOSS will pay for a single internal rebalance.
 The value is in parts-per-million (PPM) of the amount being moved.
-The default is `5000` (0.5% of the amount). Both the
+The default is `1000` (0.1% of the amount). Both the
 JitRebalancer and EarningsRebalancer honor this limit.
 
 ### `clboss-recent-earnings`, `clboss-earnings-history`

--- a/README.md
+++ b/README.md
@@ -482,6 +482,13 @@ suffix, e.g.
 
     lightningd --clboss-min-channel=1000000
 
+### `--clboss-max-rebalance-fee-ppm=<ppm>`
+
+Limits the fee CLBOSS will pay for a single internal rebalance.
+The value is in parts-per-million (PPM) of the amount being moved.
+The default is `5000` (0.5% of the amount). Both the
+JitRebalancer and EarningsRebalancer honor this limit.
+
 ### `clboss-recent-earnings`, `clboss-earnings-history`
 
 As of CLBOSS version 0.14, earnings and expenditures are tracked on a daily basis.


### PR DESCRIPTION
Introduce `--clboss-max-rebalance-fee-ppm` to cap the fee allowed for a single rebalance.

Both JitRebalancer and EarningsRebalancer register and use this option, defaulting to 5000 ppm (0.5%). 

Documentation updated to explain the new setting