### PR TITLE
Add clboss-feerates RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [next rev]
+
+### Added
+
+- **RPC Enhancements**:
+  - Added the `clboss-feerates` command which reports the current fee
+    thresholds and judgment.
+
 ## [0.14.1] - 2024-12-05: "Hand at the Grindstone"
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ Possibly the most interesting are these:
   The metrics shown are for the last 3 days, though CLBOSS stores
   the raw statistics for the past two months.
 
+### `clboss-feerates`
+
+Returns the same information printed by the `onchain_feerate` section of
+`clboss-status`. It reports the current percentile thresholds, the last
+observed feerate (in perkw), and whether CLBOSS currently judges fees to
+be `low` or `high`.
+
 ### `clboss-externpay`
 
 If CLBOSS is managing a node for a custodial service, then you should

--- a/tests/boss/test_availablerpccommandsannouncer.cpp
+++ b/tests/boss/test_availablerpccommandsannouncer.cpp
@@ -25,6 +25,9 @@ auto const help = std::string(R"JSON(
   , { "command": "clboss-unmanage nodeid tags"
     , "category": "plugin"
     }
+  , { "command": "clboss-feerates"
+    , "category": "plugin"
+    }
   , { "command": "clboss-recent-earnings [days]"
     , "category": "plugin"
     }
@@ -75,11 +78,13 @@ int main() {
 		auto commands = m.commands;
 		assert(commands.count("clboss-status") != 0);
 		assert(commands.count("clboss-ignore-onchain") != 0);
-		assert(commands.count("clboss-unmanage") != 0);
-		assert(commands["clboss-status"].usage == "");
-		assert(commands["clboss-ignore-onchain"].usage == "[hours]");
-		assert(commands["clboss-unmanage"].usage == "nodeid tags");
-		assert(commands.count("clboss-recent-earnings") != 0);
+                assert(commands.count("clboss-unmanage") != 0);
+                assert(commands.count("clboss-feerates") != 0);
+                assert(commands["clboss-status"].usage == "");
+                assert(commands["clboss-ignore-onchain"].usage == "[hours]");
+                assert(commands["clboss-unmanage"].usage == "nodeid tags");
+                assert(commands["clboss-feerates"].usage == "");
+                assert(commands.count("clboss-recent-earnings") != 0);
 		assert(commands["clboss-recent-earnings"].usage == "[days]");
 		assert(commands.count("clboss-earnings-history") != 0);
 		assert(commands["clboss-earnings-history"].usage == "[nodeid]");

--- a/tests/boss/test_getmanifest.cpp
+++ b/tests/boss/test_getmanifest.cpp
@@ -22,6 +22,7 @@ auto const expected_commands = std::vector<std::string>
 , "clboss-notice-onchain"
 , "clboss-unmanage"
 , "clboss-swaps"
+, "clboss-feerates"
 };
 auto const expected_options = std::vector<std::string>
 { "clboss-min-onchain"


### PR DESCRIPTION
Add clboss-feerates so we don't have to run clboss-status just to get the fee rates ...
    
    - Register and implement the new clboss-feerates command in OnchainFeeMonitor
    - Document the command in README and note it in the changelog
    - Update RPC manifest tests to include the new command