### PR TITLE
Expose min_nodes_to_process as a configurable option

### DIFF
--- a/Boss/Mod/ChannelFinderByPopularity.cpp
+++ b/Boss/Mod/ChannelFinderByPopularity.cpp
@@ -142,7 +142,7 @@ private:
 			if (!min_nodes_to_process_set) {
 				switch (init.network) {
 				case Boss::Msg::Network_Bitcoin: min_nodes_to_process = 800; break;
-				case Boss::Msg::Network_Testnet: min_nodes_to_process = 200; break;
+				case Boss::Msg::Network_Testnet: min_nodes_to_process = 100; break;
 				default: min_nodes_to_process = 10; break; // others are likely small
 				}
 			}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **RPC Enhancements**:
   - Added the `clboss-feerates` command which reports the current fee
     thresholds and judgment.
+- **Configuration**:
+  - Added the `--clboss-min-nodes-to-process` option to control how
+    many nodes CLBOSS must know before attempting to open channels.
+    Defaults are 800 for Bitcoin, 200 for Testnet, and 10 for other
+    networks.  Setting `-1` uses these network-specific defaults.
 
 ## [0.14.1] - 2024-12-05: "Hand at the Grindstone"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Configuration**:
   - Added the `--clboss-min-nodes-to-process` option to control how
     many nodes CLBOSS must know before attempting to open channels.
-    Defaults are 800 for Bitcoin, 200 for Testnet, and 10 for other
+    Defaults are 800 for Bitcoin, 100 for Testnet, and 10 for other
     networks.  Setting `-1` uses these network-specific defaults.
 
 ## [0.14.1] - 2024-12-05: "Hand at the Grindstone"

--- a/README.md
+++ b/README.md
@@ -488,6 +488,20 @@ Limits the fee CLBOSS will pay for a single internal rebalance.
 The value is in parts-per-million (PPM) of the amount being moved.
 The default is `1000` (0.1% of the amount). Both the
 JitRebalancer and EarningsRebalancer honor this limit.
+### `--clboss-min-nodes-to-process=<number>`
+
+Sets the minimum number of nodes that CLBOSS must know about before it
+will try to propose channels to popular nodes.  Pass this option to
+`lightningd` to override the default threshold.
+
+The defaults depend on the network:
+
+* Bitcoin: 800
+* Testnet: 200
+* Other networks: 10
+
+Setting the option to `-1` reverts to the built-in network-specific
+default.
 
 ### `clboss-recent-earnings`, `clboss-earnings-history`
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ will try to propose channels to popular nodes.  Pass this option to
 The defaults depend on the network:
 
 * Bitcoin: 800
-* Testnet: 200
+* Testnet: 100
 * Other networks: 10
 
 Setting the option to `-1` reverts to the built-in network-specific

--- a/tests/boss/test_getmanifest.cpp
+++ b/tests/boss/test_getmanifest.cpp
@@ -30,6 +30,7 @@ auto const expected_options = std::vector<std::string>
 , "clboss-zerobasefee"
 , "clboss-min-channel"
 , "clboss-max-channel"
+, "clboss-min-nodes-to-process"
 };
 }
 


### PR DESCRIPTION
The testnet network is getting smaller, we keep needing to reduce the min_nodes_to_process.

Make it configurable so we don't need to rebuild/release ...

Add the following to your config file to set to a non-default value:
```
clboss-min-nodes-to-process=100
```