### PR TITLE
contrib: resolve python warning in earnings-history

### DIFF
--- a/contrib/clboss-earnings-history
+++ b/contrib/clboss-earnings-history
@@ -5,7 +5,12 @@ import csv
 import json
 import os
 import subprocess
-from datetime import datetime, UTC
+try:
+    from datetime import datetime, UTC  # 3.11+
+except ImportError:
+    from datetime import datetime, timezone
+    UTC = timezone.utc
+
 from calendar import monthrange
 
 from tabulate import tabulate

--- a/contrib/clboss-earnings-history
+++ b/contrib/clboss-earnings-history
@@ -5,7 +5,7 @@ import csv
 import json
 import os
 import subprocess
-from datetime import datetime
+from datetime import datetime, UTC
 from calendar import monthrange
 
 from tabulate import tabulate
@@ -33,7 +33,7 @@ def format_bucket_time(bucket_time):
     if bucket_time == 0:
         return "Legacy"
     else:
-        return datetime.utcfromtimestamp(bucket_time).strftime("%Y-%m-%d")
+        return datetime.fromtimestamp(bucket_time, UTC).strftime("%Y-%m-%d")
 
 
 def bucket_key(ds, bucket):
@@ -57,7 +57,7 @@ def bucket_key(ds, bucket):
 
 
 def bucket_length_days(start_ts, bucket):
-    dt = datetime.utcfromtimestamp(start_ts)
+    dt = datetime.fromtimestamp(start_ts, UTC)
     if bucket == "day":
         return 1
     elif bucket == "week":


### PR DESCRIPTION
When running under python 3.12.3, clboss-earnings-history produces the warning: clboss-earnings-history:36: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).