### PR TITLE
Change master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You need to install the below first before you can run
     pkg install git
 
 While releases and pre-releases will be tested for
-compileability in a FreeBSD VM, git `master` may
+compileability in a FreeBSD VM, git `main` may
 transiently be in a state where the default CLANG may
 raise warnings that are not raised by GCC, or may refer to
 Linux-specific header files and functions.


### PR DESCRIPTION
This PR tracks the rename of the project’s default branch from master to main. The change aligns CLBOSS with current common convention across the ecosystem, reduces friction for new contributors (many tools and templates assume main), and keeps the project consistent with modern platform defaults. No code behavior is intended to change; this is a repository hygiene/maintenance update, and documentation/automation references are adjusted accordingly.
  
  - “Default branch is changing from master to main on DATE. Existing clones will keep working,
        but you may want to update your local branch name and upstream.”
      - “If you have a local clone:”
          - git fetch origin
          - git branch -m master main (or, if you’re on a different branch, rename your local
            master)
          - git branch -u origin/main main
          - git remote set-head origin -a
      - “If you have automation or scripts that reference master, update them to main.”
      - “If you have an open PR, the base branch should update automatically; if not, retarget to
        main.”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated FreeBSD VM compilation documentation to reflect current git branch naming conventions, changing references from "master" to "main" for improved clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->