### PR TITLE
Fix: Replace std::result_of with std::invoke_result_t for C++20

### DIFF
--- a/Ev/Io.hpp
+++ b/Ev/Io.hpp
@@ -91,9 +91,9 @@ public:
 
 	/* (>>=) :: IO a -> (a -> IO b) -> IO b*/
 	template<typename f>
-	Io<typename Detail::IoInner<typename std::result_of<f(a)>::type>::type>
+	Io<typename Detail::IoInner<std::invoke_result_t<f, a>>::type>
 	then(f func)&& {
-		using b = typename Detail::IoInner<typename std::result_of<f(a)>::type>::type;
+		using b = typename Detail::IoInner<std::invoke_result_t<f, a>>::type;
 		auto pcore = std::make_shared<CoreFunc>(std::move(this->core));
 		auto pfunc = std::make_shared<f>(std::move(func));
 		/* Continuation Monad.  */
@@ -150,9 +150,9 @@ public:
 
 	/* (>>=) :: IO () -> (() -> IO b) -> IO b*/
 	template<typename f>
-	Io<typename Detail::IoInner<typename std::result_of<f()>::type>::type>
+	Io<typename Detail::IoInner<std::invoke_result_t<f>>::type>
 	then(f func)&& {
-		using b = typename Detail::IoInner<typename std::result_of<f()>::type>::type;
+		using b = typename Detail::IoInner<std::invoke_result_t<f>>::type;
 		auto pcore = std::make_shared<CoreFunc>(std::move(this->core));
 		auto pfunc = std::make_shared<f>(std::move(func));
 		/* Continuation Monad.  */

--- a/Ev/map.hpp
+++ b/Ev/map.hpp
@@ -43,7 +43,7 @@ namespace Ev {
  */
 /* mapIO :: (a -> IO b) -> [a] -> IO [b] */
 template<typename f, typename a>
-Io<std::vector<typename Detail::IoInner<typename std::result_of<f(a)>::type>::type>>
+Io<std::vector<typename Detail::IoInner<std::invoke_result_t<f, a>>::type>>
 map(f func, std::vector<a> as);
 
 namespace Detail {
@@ -209,9 +209,9 @@ public:
 }
 
 template<typename f, typename a>
-Io<std::vector<typename Detail::IoInner<typename std::result_of<f(a)>::type>::type>>
+Io<std::vector<typename Detail::IoInner<std::invoke_result_t<f, a>>::type>>
 map(f func, std::vector<a> as) {
-	using b = typename Detail::IoInner<typename std::result_of<f(a)>::type>::type;
+	using b = typename Detail::IoInner<std::invoke_result_t<f, a>>::type;
 
 	/* Save the function into shared storage.  */
 	auto pfunc = std::make_shared<f>(std::move(func));


### PR DESCRIPTION
std::result_of was deprecated in C++17 and removed in C++20. This patch replaces it with std::invoke_result_t which is the modern equivalent.

Fixes build on systems with C++20 compilers (e.g., FreeBSD 14+ with clang 18).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Replaces deprecated `std::result_of` with `std::invoke_result_t` in Ev/Io.hpp and Ev/map.hpp to ensure C++20 compatibility, addressing removal of `std::result_of` in C++20 standard.

Updates two `then()` template methods in Ev::Io class and the public `map()` function to use `std::invoke_result_t` for computing return types, maintaining equivalent functionality while using the modern type trait.

Minimal changes across two headers (4 lines modified total) with no impact to control flow or execution logic—only type computation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->