### PR TITLE
feat: add clang C++20 build job to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,3 +71,33 @@ jobs:
       with:
         name: coverage-lcov
         path: coverage.info
+
+  build-clang:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install clang and build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          autoconf \
+          autoconf-archive \
+          automake \
+          build-essential \
+          clang \
+          curl \
+          git \
+          libcurl4-openssl-dev \
+          libev-dev \
+          libsqlite3-dev \
+          libtool \
+          libunwind-dev \
+          pkg-config
+    - name: Configure (clang)
+      run: |
+        autoreconf -fi
+        ./configure CC=clang CXX=clang++
+    - name: Build
+      run: make -j2
+    - name: Run unit tests
+      run: make -j2 check-TESTS

--- a/Bitcoin/Tx.hpp
+++ b/Bitcoin/Tx.hpp
@@ -1,6 +1,7 @@
 #ifndef BITCOIN_TX_HPP
 #define BITCOIN_TX_HPP
 
+#include<cstdint>
 #include"Bitcoin/TxIn.hpp"
 #include"Bitcoin/TxOut.hpp"
 

--- a/Boltz/Detail/ServiceImpl.hpp
+++ b/Boltz/Detail/ServiceImpl.hpp
@@ -5,6 +5,7 @@
 #include"Boltz/Service.hpp"
 #include"Secp256k1/Random.hpp"
 #include"Sqlite3/Db.hpp"
+#include<cstdint>
 #include<functional>
 #include<memory>
 

--- a/Boss/Mod/BoltzSwapper/Env.hpp
+++ b/Boss/Mod/BoltzSwapper/Env.hpp
@@ -1,6 +1,7 @@
 #ifndef BOSS_MOD_BOLTZSWAPPER_ENV_HPP
 #define BOSS_MOD_BOLTZSWAPPER_ENV_HPP
 
+#include<cstdint>
 #include"Boltz/EnvIF.hpp"
 
 namespace Boss { namespace Mod { class Rpc; }}

--- a/Boss/Msg/ProvideChannelFeeModifier.hpp
+++ b/Boss/Msg/ProvideChannelFeeModifier.hpp
@@ -1,6 +1,7 @@
 #ifndef BOSS_MSG_PROVIDECHANNELFEEMODIFIER_HPP
 #define BOSS_MSG_PROVIDECHANNELFEEMODIFIER_HPP
 
+#include<cstdint>
 #include<functional>
 
 namespace Ev { template<typename a> class Io; }

--- a/Boss/Msg/SendpayResult.hpp
+++ b/Boss/Msg/SendpayResult.hpp
@@ -1,6 +1,7 @@
 #ifndef BOSS_MSG_SENDPAYRESULT_HPP
 #define BOSS_MSG_SENDPAYRESULT_HPP
 
+#include<cstdint>
 #include"Ln/NodeId.hpp"
 #include"Sha256/Hash.hpp"
 

--- a/Jsmn/Parser.hpp
+++ b/Jsmn/Parser.hpp
@@ -4,8 +4,6 @@
 #include"Jsmn/ParserExposedBuffer.hpp"
 #include<algorithm>
 
-namespace Jsmn { class Object; }
-
 namespace Jsmn {
 
 /* A stateful jsmn-based parser.

--- a/Jsmn/ParserExposedBuffer.hpp
+++ b/Jsmn/ParserExposedBuffer.hpp
@@ -8,9 +8,8 @@
 #include<string>
 #include<utility>
 #include<vector>
+#include"Jsmn/Object.hpp"
 #include"Jsmn/ParseError.hpp"
-
-namespace Jsmn { class Object; }
 
 namespace Jsmn {
 

--- a/Ln/Scid.hpp
+++ b/Ln/Scid.hpp
@@ -3,6 +3,7 @@
 
 #include "Util/Compiler.hpp"
 #include<cstddef>
+#include<cstdint>
 #include<string>
 #include<iostream>
 

--- a/Net/SocketFd.hpp
+++ b/Net/SocketFd.hpp
@@ -2,6 +2,7 @@
 #define NET_SOCKETFD_HPP
 
 #include<cstddef>
+#include<cstdint>
 #include<utility>
 #include<vector>
 #include"Net/Fd.hpp"

--- a/Sha256/fun.hpp
+++ b/Sha256/fun.hpp
@@ -1,6 +1,7 @@
 #ifndef SHA256_FUN_HPP
 #define SHA256_FUN_HPP
 
+#include<cstdint>
 #include"Sha256/Hash.hpp"
 #include"Sha256/Hasher.hpp"
 

--- a/Util/Bech32.hpp
+++ b/Util/Bech32.hpp
@@ -2,6 +2,7 @@
 #define UTIL_BECH32_HPP
 
 #include "Compiler.hpp"
+#include<cstdint>
 #include<stdexcept>
 #include<string>
 #include<vector>

--- a/configure.ac
+++ b/configure.ac
@@ -78,8 +78,9 @@ PKG_CHECK_MODULES([LIBUNWIND], [libunwind], [
 ])
 
 # https://github.com/ZmnSCPxj/clboss/issues/245
+# Alpine and FreeBSD need explicit -lexecinfo for backtrace_symbols
 case "$host_os" in
-  *alpine*)
+  *alpine*|*freebsd*)
     LDFLAGS="$LDFLAGS -lexecinfo"
     ;;
 esac

--- a/tests/boss/test_earningsrebalancer.cpp
+++ b/tests/boss/test_earningsrebalancer.cpp
@@ -90,7 +90,7 @@ public:
 			auto js = Jsmn::Object();
 			is >> js;
 			return bus.raise(Boss::Msg::ListpeersResult{
-					std::move(Boss::Mod::convert_legacy_listpeers(js)), false
+					Boss::Mod::convert_legacy_listpeers(js), false
 			});
 		});
 	}

--- a/tests/boss/test_initialrebalancer.cpp
+++ b/tests/boss/test_initialrebalancer.cpp
@@ -96,8 +96,8 @@ Ev::Io<void> listpeers_result(S::Bus& bus, std::string const& json) {
 	auto js = Jsmn::Object();
 	is >> js;
 
-	return bus.raise(ListpeersResult{std::move(
-				Boss::Mod::convert_legacy_listpeers(js)), false});
+	return bus.raise(ListpeersResult{
+				Boss::Mod::convert_legacy_listpeers(js), false});
 }
 
 Ev::Io<void> multiyield() {

--- a/tests/boss/test_jitrebalancer.cpp
+++ b/tests/boss/test_jitrebalancer.cpp
@@ -337,7 +337,7 @@ int main() {
 		auto res = Jsmn::Object::parse_json(listpeers_result);
 		auto peers = res["peers"];
 		return bus.raise(Boss::Msg::ListpeersResult{
-				std::move(Boss::Mod::convert_legacy_listpeers(peers)), true
+				Boss::Mod::convert_legacy_listpeers(peers), true
 		});
 	}).then([&]() {
 

--- a/tests/util/test_either.cpp
+++ b/tests/util/test_either.cpp
@@ -80,7 +80,7 @@ int main() {
 		a.swap(b);
 		assert(b < a);
 		a = b;
-		a = a;
+		{ auto& ref = a; a = ref; } // Intentional self-assignment test
 		assert(a == b);
 
 		a = Example::left(0);


### PR DESCRIPTION
Add clang build configuration to catch C++20 compatibility issues early.

Changes:
- Add build-clang job to .github/workflows/build.yml
- Add missing #include<cstdint> for std::uint* types (clang strict mode)
- Add -lexecinfo for FreeBSD in configure.ac (backtrace_symbols)
- Fix pessimizing-move warning in test_earningsrebalancer.cpp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a new clang C++20 build job to GitHub Actions CI workflow to detect C++20 compatibility issues and ensure strict mode compilation across the codebase.
- Added missing #include <cstdint> headers across 9 header files (Bitcoin/Tx.hpp, Boltz/Detail/ServiceImpl.hpp, Boss/Mod/BoltzSwapper/Env.hpp, Boss/Msg/ProvideChannelFeeModifier.hpp, Boss/Msg/SendpayResult.hpp, Ln/Scid.hpp, Net/SocketFd.hpp, Sha256/fun.hpp, Util/Bech32.hpp) to properly support std::uint* types required by clang's strict compilation mode.
- Updated build configuration to link -lexecinfo on FreeBSD (configure.ac), replaced forward declaration with full include in Jsmn/ParserExposedBuffer.hpp, and removed unnecessary std::move operations in test files to fix pessimizing-move warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->