### PR TITLE
draft: Verify invoice payment_hash matches swap preimage hash

### DIFF
--- a/Boltz/Detail/SwapSetupHandler.cpp
+++ b/Boltz/Detail/SwapSetupHandler.cpp
@@ -2,6 +2,7 @@
 #include"Boltz/ConnectionIF.hpp"
 #include"Boltz/Detail/SwapSetupHandler.hpp"
 #include"Boltz/Detail/compute_preimage.hpp"
+#include"Boltz/Detail/construct_redeemscript.hpp"
 #include"Boltz/Detail/match_lockscript.hpp"
 #include"Boltz/EnvIF.hpp"
 #include"Boltz/SwapInfo.hpp"
@@ -16,24 +17,6 @@
 #include<sstream>
 
 namespace {
-
-// Bitcoin Script opcodes for the reverse submarine swap HTLC template.
-// Same template as Electrum WITNESS_TEMPLATE_SWAP and boltz-core swapScript().
-constexpr std::uint8_t OP_SIZE              = 0x82;
-constexpr std::uint8_t OP_EQUAL             = 0x87;
-constexpr std::uint8_t OP_IF                = 0x63;
-constexpr std::uint8_t OP_HASH160           = 0xa9;
-constexpr std::uint8_t OP_EQUALVERIFY       = 0x88;
-constexpr std::uint8_t OP_ELSE              = 0x67;
-constexpr std::uint8_t OP_DROP              = 0x75;
-constexpr std::uint8_t OP_CHECKLOCKTIMEVERIFY = 0xb1;
-constexpr std::uint8_t OP_ENDIF             = 0x68;
-constexpr std::uint8_t OP_CHECKSIG          = 0xac;
-constexpr std::uint8_t PUSHBYTE_1           = 0x01;
-constexpr std::uint8_t PUSHBYTE_3           = 0x03;
-constexpr std::uint8_t PUSHBYTE_20          = 0x14;
-constexpr std::uint8_t PUSHBYTE_32          = 0x20;
-constexpr std::uint8_t PUSHBYTE_33          = 0x21;
 
 /* Thrown to get out and fail.  */
 struct Fail {};
@@ -181,42 +164,12 @@ Ev::Io<void> SwapSetupHandler::core_run() {
 		// REF: electrum/submarine_swaps.py _check_swap_scriptcode(): rebuilds script from
 		//   scratch and compares: "if redeem_script != _construct_swap_scriptcode(...): raise"
 		{
-			auto expected = std::vector<std::uint8_t>();
-			expected.push_back(OP_SIZE);
-			expected.push_back(PUSHBYTE_1);
-			expected.push_back(PUSHBYTE_32);
-			expected.push_back(OP_EQUAL);
-			expected.push_back(OP_IF);
-			expected.push_back(OP_HASH160);
-			expected.push_back(PUSHBYTE_20);
-			{
-				std::uint8_t buf[20];
-				script_hash160.to_buffer(buf);
-				expected.insert(expected.end(), buf, buf + 20);
-			}
-			expected.push_back(OP_EQUALVERIFY);
-			expected.push_back(PUSHBYTE_33);
-			{
-				std::uint8_t buf[33];
-				script_mypubkey.to_buffer(buf);
-				expected.insert(expected.end(), buf, buf + 33);
-			}
-			expected.push_back(OP_ELSE);
-			expected.push_back(OP_DROP);
-			expected.push_back(PUSHBYTE_3);
-			expected.push_back(std::uint8_t(tmp_timeoutBlockheight & 0xFF));
-			expected.push_back(std::uint8_t((tmp_timeoutBlockheight >> 8) & 0xFF));
-			expected.push_back(std::uint8_t((tmp_timeoutBlockheight >> 16) & 0xFF));
-			expected.push_back(OP_CHECKLOCKTIMEVERIFY);
-			expected.push_back(OP_DROP);
-			expected.push_back(PUSHBYTE_33);
-			{
-				std::uint8_t buf[33];
-				script_theirpubkey.to_buffer(buf);
-				expected.insert(expected.end(), buf, buf + 33);
-			}
-			expected.push_back(OP_ENDIF);
-			expected.push_back(OP_CHECKSIG);
+			auto expected = Detail::construct_redeemscript
+				( script_hash160
+				, script_mypubkey
+				, tmp_timeoutBlockheight
+				, script_theirpubkey
+				);
 
 			if (expected != tmp_redeemScript) {
 				return loge( std::string("redeemScript byte-compare "

--- a/Boltz/Detail/SwapSetupHandler.cpp
+++ b/Boltz/Detail/SwapSetupHandler.cpp
@@ -17,6 +17,24 @@
 
 namespace {
 
+// Bitcoin Script opcodes for the reverse submarine swap HTLC template.
+// Same template as Electrum WITNESS_TEMPLATE_SWAP and boltz-core swapScript().
+constexpr std::uint8_t OP_SIZE              = 0x82;
+constexpr std::uint8_t OP_EQUAL             = 0x87;
+constexpr std::uint8_t OP_IF                = 0x63;
+constexpr std::uint8_t OP_HASH160           = 0xa9;
+constexpr std::uint8_t OP_EQUALVERIFY       = 0x88;
+constexpr std::uint8_t OP_ELSE              = 0x67;
+constexpr std::uint8_t OP_DROP              = 0x75;
+constexpr std::uint8_t OP_CHECKLOCKTIMEVERIFY = 0xb1;
+constexpr std::uint8_t OP_ENDIF             = 0x68;
+constexpr std::uint8_t OP_CHECKSIG          = 0xac;
+constexpr std::uint8_t PUSHBYTE_1           = 0x01;
+constexpr std::uint8_t PUSHBYTE_3           = 0x03;
+constexpr std::uint8_t PUSHBYTE_20          = 0x14;
+constexpr std::uint8_t PUSHBYTE_32          = 0x20;
+constexpr std::uint8_t PUSHBYTE_33          = 0x21;
+
 /* Thrown to get out and fail.  */
 struct Fail {};
 
@@ -151,6 +169,67 @@ Ev::Io<void> SwapSetupHandler::core_run() {
 			});
 		}
 
+		/* Rebuild the expected script from our known parameters and
+		 * byte-compare, following the same pattern as Electrum's
+		 * _construct_swap_scriptcode / _check_swap_scriptcode.
+		 * Ref: electrum/submarine_swaps.py
+		 *   "if redeem_script != _construct_swap_scriptcode(...): raise"
+		 */
+		// SPEC (Boltz dont-trust-verify.md): "clients should verify that the redeem script
+		// is valid by checking preimage hash, public key, timeout block height of the HTLC and OP codes"
+		// REF: https://github.com/BoltzExchange/boltz-backend/blob/master/docs/dont-trust-verify.md
+		// REF: electrum/submarine_swaps.py _check_swap_scriptcode(): rebuilds script from
+		//   scratch and compares: "if redeem_script != _construct_swap_scriptcode(...): raise"
+		{
+			auto expected = std::vector<std::uint8_t>();
+			expected.push_back(OP_SIZE);
+			expected.push_back(PUSHBYTE_1);
+			expected.push_back(PUSHBYTE_32);
+			expected.push_back(OP_EQUAL);
+			expected.push_back(OP_IF);
+			expected.push_back(OP_HASH160);
+			expected.push_back(PUSHBYTE_20);
+			{
+				std::uint8_t buf[20];
+				script_hash160.to_buffer(buf);
+				expected.insert(expected.end(), buf, buf + 20);
+			}
+			expected.push_back(OP_EQUALVERIFY);
+			expected.push_back(PUSHBYTE_33);
+			{
+				std::uint8_t buf[33];
+				script_mypubkey.to_buffer(buf);
+				expected.insert(expected.end(), buf, buf + 33);
+			}
+			expected.push_back(OP_ELSE);
+			expected.push_back(OP_DROP);
+			expected.push_back(PUSHBYTE_3);
+			expected.push_back(std::uint8_t(tmp_timeoutBlockheight & 0xFF));
+			expected.push_back(std::uint8_t((tmp_timeoutBlockheight >> 8) & 0xFF));
+			expected.push_back(std::uint8_t((tmp_timeoutBlockheight >> 16) & 0xFF));
+			expected.push_back(OP_CHECKLOCKTIMEVERIFY);
+			expected.push_back(OP_DROP);
+			expected.push_back(PUSHBYTE_33);
+			{
+				std::uint8_t buf[33];
+				script_theirpubkey.to_buffer(buf);
+				expected.insert(expected.end(), buf, buf + 33);
+			}
+			expected.push_back(OP_ENDIF);
+			expected.push_back(OP_CHECKSIG);
+
+			if (expected != tmp_redeemScript) {
+				return loge( std::string("redeemScript byte-compare "
+						 "mismatch (script does not "
+						 "match reconstructed expected "
+						 "script)")
+					   ).then([]() {
+					throw Fail();
+					return Ev::lift();
+				});
+			}
+		}
+
 		/* FIXME: We should check the latest quotation!  */
 		if ( (Ln::Amount::sat(tmp_onchainAmount) / offchainAmount)
 		   < 0.90
@@ -165,6 +244,30 @@ Ev::Io<void> SwapSetupHandler::core_run() {
 				throw Fail();
 				return Ev::lift();
 			});
+		}
+
+		// SPEC (Boltz dont-trust-verify.md): "clients should calculate swap amounts locally to
+		// verify that expectedAmount in the API responses matches the locally calculated amount"
+		// REF: electrum/submarine_swaps.py _sanity_check_swap_costs(): rejects if costs_ratio > 0.15
+		// REF: electrum commit cbdaa035 (PR #10827)
+		{
+			auto offchain_sat = offchainAmount.to_sat();
+			auto actual_fee = offchain_sat - tmp_onchainAmount;
+			if (actual_fee > 0 && offchain_sat > 0) {
+				auto fee_ratio = double(actual_fee) / double(offchain_sat);
+				if (fee_ratio > 0.15) {
+					auto os = std::ostringstream();
+					os << "Swap fee ratio " << fee_ratio
+					   << " exceeds 15% limit (fee="
+					   << actual_fee << ", amount="
+					   << offchain_sat << ")"
+					    ;
+					return loge(os.str()).then([]() {
+						throw Fail();
+						return Ev::lift();
+					});
+				}
+			}
 		}
 
 		/* Check we have enough time.  */

--- a/Boltz/Detail/SwapSetupHandler.cpp
+++ b/Boltz/Detail/SwapSetupHandler.cpp
@@ -152,17 +152,6 @@ Ev::Io<void> SwapSetupHandler::core_run() {
 			});
 		}
 
-		/* Rebuild the expected script from our known parameters and
-		 * byte-compare, following the same pattern as Electrum's
-		 * _construct_swap_scriptcode / _check_swap_scriptcode.
-		 * Ref: electrum/submarine_swaps.py
-		 *   "if redeem_script != _construct_swap_scriptcode(...): raise"
-		 */
-		// SPEC (Boltz dont-trust-verify.md): "clients should verify that the redeem script
-		// is valid by checking preimage hash, public key, timeout block height of the HTLC and OP codes"
-		// REF: https://github.com/BoltzExchange/boltz-backend/blob/master/docs/dont-trust-verify.md
-		// REF: electrum/submarine_swaps.py _check_swap_scriptcode(): rebuilds script from
-		//   scratch and compares: "if redeem_script != _construct_swap_scriptcode(...): raise"
 		{
 			auto expected = Detail::construct_redeemscript
 				( script_hash160

--- a/Boltz/Detail/SwapSetupHandler.cpp
+++ b/Boltz/Detail/SwapSetupHandler.cpp
@@ -199,30 +199,6 @@ Ev::Io<void> SwapSetupHandler::core_run() {
 			});
 		}
 
-		// SPEC (Boltz dont-trust-verify.md): "clients should calculate swap amounts locally to
-		// verify that expectedAmount in the API responses matches the locally calculated amount"
-		// REF: electrum/submarine_swaps.py _sanity_check_swap_costs(): rejects if costs_ratio > 0.15
-		// REF: electrum commit cbdaa035 (PR #10827)
-		{
-			auto offchain_sat = offchainAmount.to_sat();
-			auto actual_fee = offchain_sat - tmp_onchainAmount;
-			if (actual_fee > 0 && offchain_sat > 0) {
-				auto fee_ratio = double(actual_fee) / double(offchain_sat);
-				if (fee_ratio > 0.15) {
-					auto os = std::ostringstream();
-					os << "Swap fee ratio " << fee_ratio
-					   << " exceeds 15% limit (fee="
-					   << actual_fee << ", amount="
-					   << offchain_sat << ")"
-					    ;
-					return loge(os.str()).then([]() {
-						throw Fail();
-						return Ev::lift();
-					});
-				}
-			}
-		}
-
 		/* Check we have enough time.  */
 		if ( current_blockheight + min_timeout > tmp_timeoutBlockheight
 		  || current_blockheight + max_timeout < tmp_timeoutBlockheight

--- a/Boltz/Detail/construct_redeemscript.cpp
+++ b/Boltz/Detail/construct_redeemscript.cpp
@@ -1,0 +1,76 @@
+#include"Boltz/Detail/construct_redeemscript.hpp"
+#include"Ripemd160/Hash.hpp"
+#include"Secp256k1/PubKey.hpp"
+
+namespace {
+
+/* Bitcoin Script opcodes for the reverse submarine swap HTLC template.
+ * Same template as Electrum WITNESS_TEMPLATE_SWAP and
+ * boltz-core swapScript().
+ */
+constexpr std::uint8_t OP_SIZE                = 0x82;
+constexpr std::uint8_t OP_EQUAL               = 0x87;
+constexpr std::uint8_t OP_IF                  = 0x63;
+constexpr std::uint8_t OP_HASH160             = 0xa9;
+constexpr std::uint8_t OP_EQUALVERIFY         = 0x88;
+constexpr std::uint8_t OP_ELSE                = 0x67;
+constexpr std::uint8_t OP_DROP                = 0x75;
+constexpr std::uint8_t OP_CHECKLOCKTIMEVERIFY = 0xb1;
+constexpr std::uint8_t OP_ENDIF               = 0x68;
+constexpr std::uint8_t OP_CHECKSIG            = 0xac;
+constexpr std::uint8_t PUSHBYTE_1             = 0x01;
+constexpr std::uint8_t PUSHBYTE_3             = 0x03;
+constexpr std::uint8_t PUSHBYTE_20            = 0x14;
+constexpr std::uint8_t PUSHBYTE_32            = 0x20;
+constexpr std::uint8_t PUSHBYTE_33            = 0x21;
+
+}
+
+namespace Boltz { namespace Detail {
+
+std::vector<std::uint8_t>
+construct_redeemscript( Ripemd160::Hash const& hash160
+		      , Secp256k1::PubKey const& pubkey_hash
+		      , std::uint32_t locktime
+		      , Secp256k1::PubKey const& pubkey_locktime
+		      ) {
+	auto expected = std::vector<std::uint8_t>();
+	expected.push_back(OP_SIZE);
+	expected.push_back(PUSHBYTE_1);
+	expected.push_back(PUSHBYTE_32);
+	expected.push_back(OP_EQUAL);
+	expected.push_back(OP_IF);
+	expected.push_back(OP_HASH160);
+	expected.push_back(PUSHBYTE_20);
+	{
+		std::uint8_t buf[20];
+		hash160.to_buffer(buf);
+		expected.insert(expected.end(), buf, buf + 20);
+	}
+	expected.push_back(OP_EQUALVERIFY);
+	expected.push_back(PUSHBYTE_33);
+	{
+		std::uint8_t buf[33];
+		pubkey_hash.to_buffer(buf);
+		expected.insert(expected.end(), buf, buf + 33);
+	}
+	expected.push_back(OP_ELSE);
+	expected.push_back(OP_DROP);
+	expected.push_back(PUSHBYTE_3);
+	expected.push_back(std::uint8_t(locktime & 0xFF));
+	expected.push_back(std::uint8_t((locktime >> 8) & 0xFF));
+	expected.push_back(std::uint8_t((locktime >> 16) & 0xFF));
+	expected.push_back(OP_CHECKLOCKTIMEVERIFY);
+	expected.push_back(OP_DROP);
+	expected.push_back(PUSHBYTE_33);
+	{
+		std::uint8_t buf[33];
+		pubkey_locktime.to_buffer(buf);
+		expected.insert(expected.end(), buf, buf + 33);
+	}
+	expected.push_back(OP_ENDIF);
+	expected.push_back(OP_CHECKSIG);
+	return expected;
+}
+
+}}

--- a/Boltz/Detail/construct_redeemscript.cpp
+++ b/Boltz/Detail/construct_redeemscript.cpp
@@ -4,10 +4,6 @@
 
 namespace {
 
-/* Bitcoin Script opcodes for the reverse submarine swap HTLC template.
- * Same template as Electrum WITNESS_TEMPLATE_SWAP and
- * boltz-core swapScript().
- */
 constexpr std::uint8_t OP_SIZE                = 0x82;
 constexpr std::uint8_t OP_EQUAL               = 0x87;
 constexpr std::uint8_t OP_IF                  = 0x63;

--- a/Boltz/Detail/construct_redeemscript.hpp
+++ b/Boltz/Detail/construct_redeemscript.hpp
@@ -1,0 +1,40 @@
+#ifndef BOLTZ_DETAIL_CONSTRUCT_REDEEMSCRIPT_HPP
+#define BOLTZ_DETAIL_CONSTRUCT_REDEEMSCRIPT_HPP
+
+#include<cstdint>
+#include<vector>
+
+namespace Ripemd160 { class Hash; }
+namespace Secp256k1 { class PubKey; }
+
+namespace Boltz { namespace Detail {
+
+/** Boltz::Detail::construct_redeemscript
+ *
+ * @brief Rebuilds the expected reverse submarine swap
+ * HTLC redeemScript from the known swap parameters.
+ *
+ * Used by SwapSetupHandler to byte-compare against the
+ * server-provided redeemScript, following Electrum's
+ * _construct_swap_scriptcode pattern.
+ *
+ * The script template is:
+ *   OP_SIZE PUSH(32) OP_EQUAL OP_IF
+ *     OP_HASH160 PUSH(20) <hash160> OP_EQUALVERIFY
+ *     PUSH(33) <pubkey_hash>
+ *   OP_ELSE
+ *     OP_DROP PUSH(3) <locktime_le3> OP_CHECKLOCKTIMEVERIFY OP_DROP
+ *     PUSH(33) <pubkey_locktime>
+ *   OP_ENDIF
+ *   OP_CHECKSIG
+ */
+std::vector<std::uint8_t>
+construct_redeemscript( Ripemd160::Hash const& hash160
+		      , Secp256k1::PubKey const& pubkey_hash
+		      , std::uint32_t locktime
+		      , Secp256k1::PubKey const& pubkey_locktime
+		      );
+
+}}
+
+#endif /* !defined(BOLTZ_DETAIL_CONSTRUCT_REDEEMSCRIPT_HPP) */

--- a/Boltz/Detail/construct_redeemscript.hpp
+++ b/Boltz/Detail/construct_redeemscript.hpp
@@ -14,10 +14,6 @@ namespace Boltz { namespace Detail {
  * @brief Rebuilds the expected reverse submarine swap
  * HTLC redeemScript from the known swap parameters.
  *
- * Used by SwapSetupHandler to byte-compare against the
- * server-provided redeemScript, following Electrum's
- * _construct_swap_scriptcode pattern.
- *
  * The script template is:
  *   OP_SIZE PUSH(32) OP_EQUAL OP_IF
  *     OP_HASH160 PUSH(20) <hash160> OP_EQUALVERIFY

--- a/Boss/Mod/InvoicePayer.cpp
+++ b/Boss/Mod/InvoicePayer.cpp
@@ -84,22 +84,31 @@ Ev::Io<void> InvoicePayer::pay(std::string n_invoice, std::string expected_hash,
 			throw Jsmn::TypeError();
 		}
 
-		if (!exp_hash->empty() && res.has("payment_hash")) {
+		if (!exp_hash->empty()) {
+			if (!res.has("payment_hash")) {
+				throw Jsmn::TypeError();
+			}
 			auto actual_hash = std::string(res["payment_hash"]);
 			if (actual_hash != *exp_hash) {
 				throw Jsmn::TypeError();
 			}
 		}
 
-		if (exp_amt != 0 && res.has("amount_msat")) {
+		if (exp_amt != 0) {
+			if (!res.has("amount_msat")) {
+				throw Jsmn::TypeError();
+			}
 			auto actual_amt = (std::uint64_t)(double)res["amount_msat"];
 			if (actual_amt != exp_amt) {
 				throw Jsmn::TypeError();
 			}
 		}
 
-		if (!exp_hash->empty() && res.has("timestamp") && res.has("expiry")) {
-			auto created = (std::time_t)(double)res["timestamp"];
+		if (!exp_hash->empty()) {
+			if (!res.has("created_at") || !res.has("expiry")) {
+				throw Jsmn::TypeError();
+			}
+			auto created = (std::time_t)(double)res["created_at"];
 			auto expiry = (std::time_t)(double)res["expiry"];
 			auto now = std::time(nullptr);
 			if (created + expiry < now) {

--- a/Boss/Mod/InvoicePayer.cpp
+++ b/Boss/Mod/InvoicePayer.cpp
@@ -11,6 +11,7 @@
 #include"S/Bus.hpp"
 #include"Util/Str.hpp"
 #include<memory>
+#include<ctime>
 
 namespace {
 
@@ -39,9 +40,8 @@ void InvoicePayer::start() {
 	bus.subscribe<Msg::Init
 		     >([this](Msg::Init const& init) {
 		rpc = &init.rpc;
-		/* Pay pending invoices.  */
-		auto f = [this](std::string invoice) {
-			return pay(std::move(invoice));
+		auto f = [this](Msg::PayInvoice p) {
+			return pay(std::move(p.invoice), std::move(p.expected_payment_hash), p.expected_amount_msat);
 		};
 		return Boss::concurrent(
 			Ev::foreach(f, std::move(pending_invoices))
@@ -51,16 +51,17 @@ void InvoicePayer::start() {
 	bus.subscribe<Msg::PayInvoice
 		     >([this](Msg::PayInvoice const& p) {
 		if (!rpc) {
-			/* Not yet ready, add to pending.  */
-			pending_invoices.push_back(p.invoice);
+			pending_invoices.push_back(p);
 			return Ev::lift();
 		}
-		return Boss::concurrent(pay(p.invoice));
+		return Boss::concurrent(pay(p.invoice, p.expected_payment_hash, p.expected_amount_msat));
 	});
 }
 
-Ev::Io<void> InvoicePayer::pay(std::string n_invoice) {
+Ev::Io<void> InvoicePayer::pay(std::string n_invoice, std::string expected_hash, std::uint64_t expected_amount) {
 	auto inv = std::make_shared<std::string>(std::move(n_invoice));
+	auto exp_hash = std::make_shared<std::string>(std::move(expected_hash));
+	auto exp_amt = expected_amount;
 	return Ev::lift().then([this, inv]() {
 		return Boss::log( bus, Debug
 				, "InvoicePayer: Initiating: %s"
@@ -73,7 +74,7 @@ Ev::Io<void> InvoicePayer::pay(std::string n_invoice) {
 			.end_object()
 			;
 		return rpc->command("decode", std::move(parms));
-	}).then([this, inv](Jsmn::Object res) {
+	}).then([this, inv, exp_hash, exp_amt](Jsmn::Object res) {
 		if (!res.has("type")
 		|| std::string(res["type"]) != "bolt11 invoice"
 		|| !res.has("valid")
@@ -81,6 +82,29 @@ Ev::Io<void> InvoicePayer::pay(std::string n_invoice) {
 		|| !bool(res["valid"])
 		) {
 			throw Jsmn::TypeError();
+		}
+
+		if (!exp_hash->empty() && res.has("payment_hash")) {
+			auto actual_hash = std::string(res["payment_hash"]);
+			if (actual_hash != *exp_hash) {
+				throw Jsmn::TypeError();
+			}
+		}
+
+		if (exp_amt != 0 && res.has("amount_msat")) {
+			auto actual_amt = (std::uint64_t)(double)res["amount_msat"];
+			if (actual_amt != exp_amt) {
+				throw Jsmn::TypeError();
+			}
+		}
+
+		if (!exp_hash->empty() && res.has("timestamp") && res.has("expiry")) {
+			auto created = (std::time_t)(double)res["timestamp"];
+			auto expiry = (std::time_t)(double)res["expiry"];
+			auto now = std::time(nullptr);
+			if (created + expiry < now) {
+				throw Jsmn::TypeError();
+			}
 		}
 
 		/* Check the features and see if this is MPP-enabled.  */

--- a/Boss/Mod/InvoicePayer.cpp
+++ b/Boss/Mod/InvoicePayer.cpp
@@ -8,6 +8,7 @@
 #include"Ev/foreach.hpp"
 #include"Jsmn/Object.hpp"
 #include"Json/Out.hpp"
+#include"Ln/Amount.hpp"
 #include"S/Bus.hpp"
 #include"Util/Str.hpp"
 #include<memory>
@@ -98,7 +99,7 @@ Ev::Io<void> InvoicePayer::pay(std::string n_invoice, std::string expected_hash,
 			if (!res.has("amount_msat")) {
 				throw Jsmn::TypeError();
 			}
-			auto actual_amt = (std::uint64_t)(double)res["amount_msat"];
+			auto actual_amt = Ln::Amount::object(res["amount_msat"]).to_msat();
 			if (actual_amt != exp_amt) {
 				throw Jsmn::TypeError();
 			}

--- a/Boss/Mod/InvoicePayer.hpp
+++ b/Boss/Mod/InvoicePayer.hpp
@@ -4,6 +4,8 @@
 #include<vector>
 #include<string>
 
+#include"Boss/Msg/PayInvoice.hpp"
+
 namespace Boss { namespace Mod { class Rpc; }}
 namespace Ev { template<typename a> class Io; }
 namespace S { class Bus; }
@@ -26,10 +28,10 @@ private:
 	S::Bus& bus;
 	Boss::Mod::Rpc* rpc;
 
-	std::vector<std::string> pending_invoices;
+	std::vector<Msg::PayInvoice> pending_invoices;
 
 	void start();
-	Ev::Io<void> pay(std::string);
+	Ev::Io<void> pay(std::string, std::string, std::uint64_t);
 
 public:
 	InvoicePayer() =delete;

--- a/Boss/Mod/SwapManager.cpp
+++ b/Boss/Mod/SwapManager.cpp
@@ -551,7 +551,7 @@ private:
 				.execute();
 			tx.commit();
 			/* Now send the PayInvoice message.  */
-			return bus.raise(Msg::PayInvoice{swap->invoice, std::string(swap->hash), swap_amount.to_msat()});
+			return bus.raise(Msg::PayInvoice{swap->invoice, std::string(swap->hash), swap_amount.to_sat() * 1000});
 		}).then([this, swap]() {
 			auto uuid = needs_invoice.front();
 			return Boss::log( bus, Debug

--- a/Boss/Mod/SwapManager.cpp
+++ b/Boss/Mod/SwapManager.cpp
@@ -509,6 +509,19 @@ private:
 					  , provider_name
 					  ](Sqlite3::Tx tx) {
 			auto uuid = needs_invoice.front();
+			auto swap_amount = Ln::Amount::sat(0);
+
+			auto amt_query = tx.query(R"QRY(
+			SELECT amount FROM "SwapManager"
+			 WHERE uuid = :uuid
+			     ;
+			)QRY")
+				.bind(":uuid", std::string(uuid))
+				.execute();
+			for (auto& r : amt_query) {
+				swap_amount = Ln::Amount::sat(r.get<std::uint64_t>(0));
+				break;
+			}
 
 			tx.query(R"QRY(
 			UPDATE "SwapManager"
@@ -538,7 +551,7 @@ private:
 				.execute();
 			tx.commit();
 			/* Now send the PayInvoice message.  */
-			return bus.raise(Msg::PayInvoice{swap->invoice});
+			return bus.raise(Msg::PayInvoice{swap->invoice, std::string(swap->hash), swap_amount.to_msat()});
 		}).then([this, swap]() {
 			auto uuid = needs_invoice.front();
 			return Boss::log( bus, Debug

--- a/Boss/Mod/SwapManager.cpp
+++ b/Boss/Mod/SwapManager.cpp
@@ -509,7 +509,7 @@ private:
 					  , provider_name
 					  ](Sqlite3::Tx tx) {
 			auto uuid = needs_invoice.front();
-			auto swap_amount = Ln::Amount::sat(0);
+			auto swap_amount = Ln::Amount::msat(0);
 
 			auto amt_query = tx.query(R"QRY(
 			SELECT amount FROM "SwapManager"
@@ -519,7 +519,7 @@ private:
 				.bind(":uuid", std::string(uuid))
 				.execute();
 			for (auto& r : amt_query) {
-				swap_amount = Ln::Amount::sat(r.get<std::uint64_t>(0));
+				swap_amount = Ln::Amount::msat(r.get<std::uint64_t>(0));
 				break;
 			}
 

--- a/Boss/Msg/PayInvoice.hpp
+++ b/Boss/Msg/PayInvoice.hpp
@@ -14,7 +14,7 @@ namespace Boss { namespace Msg {
 struct PayInvoice {
 	std::string invoice;
 	std::string expected_payment_hash;
-	std::uint64_t expected_amount_msat;
+	std::uint64_t expected_amount_msat = 0;
 };
 
 }}

--- a/Boss/Msg/PayInvoice.hpp
+++ b/Boss/Msg/PayInvoice.hpp
@@ -2,6 +2,7 @@
 #define BOSS_MSG_PAYINVOICE_HPP
 
 #include<string>
+#include<cstdint>
 
 namespace Boss { namespace Msg {
 
@@ -12,6 +13,8 @@ namespace Boss { namespace Msg {
  */
 struct PayInvoice {
 	std::string invoice;
+	std::string expected_payment_hash;
+	std::uint64_t expected_amount_msat;
 };
 
 }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -599,6 +599,7 @@ TESTS = \
 	tests/bitcoin/test_tx \
 	tests/boltz/test_match_lockscript \
 	tests/boltz/test_construct_redeemscript \
+	tests/boltz/test_swap_setup_handler \
 	tests/boss/channelcandidateinvestigator/test_gumshoe \
 	tests/boss/channelcandidateinvestigator/test_secretary \
 	tests/boss/test_availablerpccommandsannouncer \

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,8 @@ libclboss_la_SOURCES = \
 	Boltz/Detail/find_lockup_outnum.hpp \
 	Boltz/Detail/initial_claim_tx.cpp \
 	Boltz/Detail/initial_claim_tx.hpp \
+	Boltz/Detail/construct_redeemscript.cpp \
+	Boltz/Detail/construct_redeemscript.hpp \
 	Boltz/Detail/match_lockscript.cpp \
 	Boltz/Detail/match_lockscript.hpp \
 	Boltz/EnvIF.hpp \
@@ -596,6 +598,7 @@ TESTS = \
 	tests/bitcoin/test_sighash \
 	tests/bitcoin/test_tx \
 	tests/boltz/test_match_lockscript \
+	tests/boltz/test_construct_redeemscript \
 	tests/boss/channelcandidateinvestigator/test_gumshoe \
 	tests/boss/channelcandidateinvestigator/test_secretary \
 	tests/boss/test_availablerpccommandsannouncer \

--- a/tests/boltz/test_construct_redeemscript.cpp
+++ b/tests/boltz/test_construct_redeemscript.cpp
@@ -1,0 +1,83 @@
+#undef NDEBUG
+#include"Boltz/Detail/construct_redeemscript.hpp"
+#include"Boltz/Detail/match_lockscript.hpp"
+#include"Ripemd160/Hash.hpp"
+#include"Secp256k1/PubKey.hpp"
+#include"Util/Str.hpp"
+#include<assert.h>
+
+/* The valid script from test_match_lockscript.cpp (locktime 649365 = 0x09E803
+ * little-endian: 03 E8 09).
+ */
+static auto const valid_hex = std::string(
+	"8201208763a9142c2d5441ef4a4469eae063941463e3c65ee926c088"
+	"210207262fc331c1c845c6f8f7cca7a04ec3bdb09ef82cddac3eda2953c10bddd779"
+	"67750395e809b17521"
+	"030a47fa92352ac70161366dad4b45ad2a2fcbf5cef40fec43b29d33128ace529e"
+	"68ac"
+);
+
+int main() {
+	auto const hash160 = Ripemd160::Hash(
+		"2c2d5441ef4a4469eae063941463e3c65ee926c0"
+	);
+	auto const pubkey_hash = Secp256k1::PubKey(
+		"0207262fc331c1c845c6f8f7cca7a04ec3bdb09ef82cddac3eda2953c10bddd779"
+	);
+	auto const locktime = std::uint32_t(649365);
+	auto const pubkey_locktime = Secp256k1::PubKey(
+		"030a47fa92352ac70161366dad4b45ad2a2fcbf5cef40fec43b29d33128ace529e"
+	);
+
+	/* construct_redeemscript must reproduce the exact bytes of the
+	 * known-valid script that match_lockscript also accepts.
+	 */
+	auto script = Boltz::Detail::construct_redeemscript
+		( hash160
+		, pubkey_hash
+		, locktime
+		, pubkey_locktime
+		);
+	auto expected = Util::Str::hexread(valid_hex);
+	assert(script == expected);
+
+	/* Round-trip: match_lockscript must accept the script we just built.  */
+	auto rt_hash = Ripemd160::Hash();
+	auto rt_pkh = Secp256k1::PubKey();
+	auto rt_lt = std::uint32_t();
+	auto rt_pkt = Secp256k1::PubKey();
+	auto ok = Boltz::Detail::match_lockscript
+		( rt_hash, rt_pkh, rt_lt, rt_pkt, script );
+	assert(ok);
+	assert(rt_hash == hash160);
+	assert(rt_pkh == pubkey_hash);
+	assert(rt_lt == locktime);
+	assert(rt_pkt == pubkey_locktime);
+
+	/* Changing any parameter must produce a different script.  */
+	auto other_hash = Ripemd160::Hash(
+		"0000000000000000000000000000000000000000"
+	);
+	auto s2 = Boltz::Detail::construct_redeemscript
+		( other_hash, pubkey_hash, locktime, pubkey_locktime );
+	assert(s2 != script);
+
+	auto other_pk = Secp256k1::PubKey(
+		"0307262fc331c1c845c6f8f7cca7a04ec3bdb09ef82cddac3eda2953c10bddd779"
+	);
+	auto s3 = Boltz::Detail::construct_redeemscript
+		( hash160, other_pk, locktime, pubkey_locktime );
+	assert(s3 != script);
+
+	auto s4 = Boltz::Detail::construct_redeemscript
+		( hash160, pubkey_hash, locktime + 1, pubkey_locktime );
+	assert(s4 != script);
+
+	auto s5 = Boltz::Detail::construct_redeemscript
+		( hash160, pubkey_hash, locktime, other_pk );
+	assert(s5 != script);
+
+	assert(script.size() == expected.size());
+
+	return 0;
+}

--- a/tests/boltz/test_swap_setup_handler.cpp
+++ b/tests/boltz/test_swap_setup_handler.cpp
@@ -192,7 +192,6 @@ void run_test( MockConn::Mode mode
 	);
 	auto conn = MockConn(mode, current_height, their_pubkey_hex, timeout_delta);
 	auto db = Sqlite3::Db(":memory:");
-	init_db(db);
 
 	auto offchain = Ln::Amount::sat(100000);
 	auto handler = Boltz::Detail::SwapSetupHandler::create(

--- a/tests/boltz/test_swap_setup_handler.cpp
+++ b/tests/boltz/test_swap_setup_handler.cpp
@@ -1,0 +1,235 @@
+#undef NDEBUG
+#include"Bitcoin/hash160.hpp"
+#include"Bitcoin/Tx.hpp"
+#include"Boltz/ConnectionIF.hpp"
+#include"Boltz/Detail/construct_redeemscript.hpp"
+#include"Boltz/Detail/SwapSetupHandler.hpp"
+#include"Boltz/EnvIF.hpp"
+#include"Boltz/SwapInfo.hpp"
+#include"Ev/Io.hpp"
+#include"Ev/start.hpp"
+#include"Jsmn/Object.hpp"
+#include"Jsmn/Parser.hpp"
+#include"Json/Out.hpp"
+#include"Ln/Amount.hpp"
+#include"Ln/Preimage.hpp"
+#include"Ripemd160/Hash.hpp"
+#include"Ripemd160/Hasher.hpp"
+#include"Secp256k1/G.hpp"
+#include"Secp256k1/PubKey.hpp"
+#include"Secp256k1/Random.hpp"
+#include"Secp256k1/SignerIF.hpp"
+#include"Secp256k1/PrivKey.hpp"
+#include"Secp256k1/Signature.hpp"
+#include"Sha256/Hash.hpp"
+#include"Sqlite3.hpp"
+#include"Util/Str.hpp"
+#include"Util/make_unique.hpp"
+#include<assert.h>
+#include<memory>
+#include<string>
+
+namespace {
+
+class DummySigner : public Secp256k1::SignerIF {
+public:
+	Secp256k1::PubKey
+	get_pubkey_tweak( Secp256k1::PrivKey const& tweak
+			     ) override {
+		(void) tweak;
+		return Secp256k1::PubKey();
+	}
+
+	Secp256k1::Signature
+	get_signature_tweak( Secp256k1::PrivKey const& tweak
+			 , Sha256::Hash const& m
+			 ) override {
+		(void) tweak;
+		(void) m;
+		return Secp256k1::Signature();
+	}
+
+	Sha256::Hash
+	get_privkey_salted_hash( std::uint8_t salt[32]
+			       ) override {
+		if (!salt)
+			return Sha256::Hash();
+		auto hash = Sha256::Hash();
+		hash.from_buffer(salt);
+		return hash;
+	}
+};
+
+class MockEnv : public Boltz::EnvIF {
+public:
+	Ev::Io<std::uint32_t> get_feerate() override {
+		return Ev::lift(std::uint32_t(1000));
+	}
+	Ev::Io<bool> broadcast_tx(Bitcoin::Tx) override {
+		return Ev::lift(true);
+	}
+	Ev::Io<void> logd(std::string) override { return Ev::lift(); }
+	Ev::Io<void> loge(std::string) override { return Ev::lift(); }
+};
+
+/* Builds a createswap response containing a redeemScript that matches
+ * the parameters extracted from the request.  Corrupt the script or
+ * adjust onchainAmount to trigger rejection paths.
+ */
+class MockConn : public Boltz::ConnectionIF {
+public:
+	enum class Mode { Valid, BadScript, LowOnchain };
+
+private:
+	Mode mode;
+	std::uint32_t current_height;
+	std::string their_pubkey_hex;
+	std::uint32_t timeout_delta;
+
+public:
+	MockConn( Mode mode_
+		, std::uint32_t current_height_
+		, std::string their_pubkey_hex_
+		, std::uint32_t timeout_delta_ = 100
+		) : mode(mode_)
+		  , current_height(current_height_)
+		  , their_pubkey_hex(std::move(their_pubkey_hex_))
+		  , timeout_delta(timeout_delta_)
+	{ }
+
+	Ev::Io<Jsmn::Object>
+	api( std::string api
+	   , std::unique_ptr<Json::Out> params
+	   ) override {
+		assert(api == "/createswap");
+
+		auto timeout = current_height + timeout_delta;
+
+		auto params_str = params->output();
+		auto parser = Jsmn::Parser();
+		auto parsed = parser.feed(params_str);
+		auto& req = parsed.front();
+
+		auto preimageHash_hex = std::string(req["preimageHash"]);
+		auto claimPubkey_hex = std::string(req["claimPublicKey"]);
+
+		auto ph_bytes = Util::Str::hexread(preimageHash_hex);
+		auto hasher = Ripemd160::Hasher();
+		hasher.feed(ph_bytes.data(), ph_bytes.size());
+		auto hash160 = std::move(hasher).finalize();
+
+		auto claim_pubkey = Secp256k1::PubKey(claimPubkey_hex);
+		auto their_pubkey = Secp256k1::PubKey(their_pubkey_hex);
+
+		auto script = Boltz::Detail::construct_redeemscript(
+			hash160, claim_pubkey, timeout, their_pubkey
+		);
+
+		if (mode == Mode::BadScript) {
+			script[10] ^= 0xFF;
+		}
+
+		auto script_hex = Util::Str::hexdump(
+			script.data(), script.size()
+		);
+
+		auto offchain_sat = std::uint64_t(
+			double(req["invoiceAmount"])
+		);
+		auto onchain_sat = offchain_sat;
+		if (mode == Mode::LowOnchain)
+			onchain_sat = offchain_sat / 2;
+
+		auto response = std::string();
+		response = Json::Out()
+			.start_object()
+				.field("id", std::string("test-swap-id"))
+				.field("redeemScript", script_hex)
+				.field("invoice", std::string("lnbc1testinvoice"))
+				.field("timeoutBlockHeight", double(timeout))
+				.field("onchainAmount", double(onchain_sat))
+			.end_object()
+			.output();
+		return Ev::lift(Jsmn::Object::parse_json(response.c_str()));
+	}
+};
+
+Ev::Io<void> init_db(Sqlite3::Db& db) {
+	return db.transact().then([](Sqlite3::Tx tx) {
+		tx.query_execute(R"QRY(
+		CREATE TABLE IF NOT EXISTS "BoltzServiceFactory_rsub"
+		     ( id INTEGER PRIMARY KEY
+		     , apiAccess TEXT NOT NULL
+		     , tweak TEXT NOT NULL
+		     , preimage TEXT NOT NULL
+		     , destinationAddress TEXT NOT NULL
+		     , swapId TEXT NOT NULL
+		     , redeemScript TEXT NOT NULL
+		     , timeoutBlockheight INTEGER NOT NULL
+		     , onchainAmount INTEGER NOT NULL
+		     , lockedUp INTEGER NOT NULL
+		     , lockupTxid TEXT NULL
+		     , lockupOut INTEGER NULL
+		     , lockupConfirmedHeight INTEGER NULL
+		     , lockupClaimFees INTEGER NULL
+		     , comment TEXT
+		     );
+		)QRY");
+		tx.commit();
+		return Ev::lift();
+	});
+}
+
+void run_test( MockConn::Mode mode
+	     , std::uint32_t current_height
+	     , std::uint32_t timeout_delta = 100
+	     ) {
+	auto random = Secp256k1::Random();
+	auto signer = DummySigner();
+	auto env = MockEnv();
+	auto their_pubkey_hex = std::string(
+		"0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+	);
+	auto conn = MockConn(mode, current_height, their_pubkey_hex, timeout_delta);
+	auto db = Sqlite3::Db(":memory:");
+	init_db(db);
+
+	auto offchain = Ln::Amount::sat(100000);
+	auto handler = Boltz::Detail::SwapSetupHandler::create(
+		signer, db, env, "http://test.boltz",
+		conn, random,
+		std::string("bc1qtestdestination"),
+		offchain, current_height
+	);
+
+	auto got = std::make_shared<Boltz::SwapInfo>();
+	auto code = init_db(db).then([&handler, got]() {
+		return handler->run();
+	}).then([got](Boltz::SwapInfo info) {
+		*got = std::move(info);
+		return Ev::lift(0);
+	});
+
+	auto ec = Ev::start(code);
+	assert(ec == 0);
+
+	if (mode == MockConn::Mode::Valid) {
+		assert(!got->invoice.empty());
+		assert(got->timeout == current_height + timeout_delta);
+	} else {
+		assert(got->invoice.empty());
+		assert(got->timeout == 0);
+	}
+}
+
+} // namespace
+
+int main() {
+	auto const height = std::uint32_t(800000);
+
+	run_test(MockConn::Mode::Valid, height);
+	run_test(MockConn::Mode::BadScript, height);
+	run_test(MockConn::Mode::LowOnchain, height);
+
+	return 0;
+}

--- a/tests/boss/test_invoicepayer_decodepay.cpp
+++ b/tests/boss/test_invoicepayer_decodepay.cpp
@@ -23,6 +23,7 @@
 #include"Sha256/Hash.hpp"
 #include"Sqlite3.hpp"
 #include<assert.h>
+#include<ctime>
 #include<deque>
 #include<errno.h>
 #include<fcntl.h>
@@ -33,6 +34,15 @@
 #include<unistd.h>
 
 namespace {
+
+/* The payment_hash and amount_msat baked into the canonical decode
+ * response below.  Tests that exercise the verification logic vary
+ * these values to trigger acceptance or rejection.
+ */
+auto const GOOD_HASH = std::string(
+	"7814817188071aec26c943f4864ef150aaff45def81b36b0dd4bc6ce8f1809a3"
+);
+auto const GOOD_AMOUNT = std::uint64_t(1000000);
 
 class DummyConnector : public Net::Connector {
 public:
@@ -74,12 +84,47 @@ public:
 	}
 };
 
+/* Build a decode-response JSON string with configurable payment_hash,
+ * amount_msat, created_at timestamp, and expiry.  The rest of the
+ * fields mirror a real CLN decode result.
+ */
+std::string make_decode_response( std::string const& payment_hash
+				, std::uint64_t amount_msat
+				, double created_at
+				, double expiry
+				) {
+	auto os = std::ostringstream();
+	os << R"({
+	   "type": "bolt11 invoice",
+	   "currency": "tb",
+	   "created_at": )"
+	   << created_at << R"(,
+	   "expiry": )"
+	   << expiry << R"(,
+	   "payee": "0225bbc2a7341993cd592d7b0c185bb8c6359cc1dd1337975c6d41354e4703bf64",
+	   "amount_msat": )"
+	   << amount_msat << R"(,
+	   "description": "decode testing",
+	   "min_final_cltv_expiry": 10,
+	   "payment_secret": "d8577cf3c01f0b9b124adee87f552c2b3195db83f4dea30874d5b27d26201e85",
+	   "features": "02024100",
+	   "routes": [],
+	   "payment_hash": ")"
+	   << payment_hash << R"(",
+	   "signature": "3045022100e745b9b7fe8133c7385e40561217e4717f7a2868c60d794b160047512c8d3a79022074619d6d2ee5c07b3099ca3684f896886aab04854bfade8f5a0f9014d5418ab6",
+	   "valid": true
+	})";
+	return os.str();
+}
+
 class MockRpcServer {
 private:
 	Net::Fd socket;
 	Jsmn::Parser parser;
 	std::deque<Jsmn::Object> requests;
 	std::shared_ptr<bool> pay_replied;
+	std::string decode_response;
+	bool expect_pay;
 
 	Ev::Io<Jsmn::Object> read_request(std::size_t retries = 0) {
 		return Ev::yield().then([this]() {
@@ -151,7 +196,17 @@ private:
 	}
 
 public:
-	MockRpcServer(Net::Fd socket_, std::shared_ptr<bool> pay_replied_) : socket(std::move(socket_)), parser(), requests(), pay_replied(std::move(pay_replied_)) {
+	MockRpcServer( Net::Fd socket_
+		     , std::shared_ptr<bool> pay_replied_
+		     , std::string decode_response_
+		     , bool expect_pay_
+		     ) : socket(std::move(socket_))
+		       , parser()
+		       , requests()
+		       , pay_replied(std::move(pay_replied_))
+		       , decode_response(std::move(decode_response_))
+		       , expect_pay(expect_pay_)
+	{
 		auto flags = fcntl(socket.get(), F_GETFL);
 		assert(flags >= 0);
 		flags |= O_NONBLOCK;
@@ -166,33 +221,12 @@ public:
 			assert(params.is_object());
 			assert(params.has("string"));
 			assert(std::string(params["string"]) == invoice);
-			return reply_result(id, R"({
-			   "type": "bolt11 invoice",
-			   "currency": "tb",
-			   "created_at": 1771010577,
-			   "expiry": 604800,
-			   "payee": "0225bbc2a7341993cd592d7b0c185bb8c6359cc1dd1337975c6d41354e4703bf64",
-			   "amount_msat": 1000000,
-			   "description": "decode testing",
-			   "min_final_cltv_expiry": 10,
-			   "payment_secret": "d8577cf3c01f0b9b124adee87f552c2b3195db83f4dea30874d5b27d26201e85",
-			   "features": "02024100",
-			   "routes": [
-			      [
-			         {
-			            "pubkey": "031c64a68e6d1b9e50711336d92b434c584ce668b2fae59ee688bd73713fee1569",
-			            "short_channel_id": "4659673x21x0",
-			            "fee_base_msat": 2000,
-			            "fee_proportional_millionths": 2,
-			            "cltv_expiry_delta": 80
-			         }
-			      ]
-			   ],
-			   "payment_hash": "7814817188071aec26c943f4864ef150aaff45def81b36b0dd4bc6ce8f1809a3",
-			   "signature": "3045022100e745b9b7fe8133c7385e40561217e4717f7a2868c60d794b160047512c8d3a79022074619d6d2ee5c07b3099ca3684f896886aab04854bfade8f5a0f9014d5418ab6",
-			   "valid": true
-			})");
+			return reply_result(id, decode_response);
 		}).then([this, invoice]() {
+			if (!expect_pay)
+				/* Payer should reject the invoice; no pay
+				 * request will arrive.  */
+				return Ev::lift();
 			return read_request().then([this, invoice](Jsmn::Object req) {
 				auto id = assert_method(req, "pay");
 				auto params = req["params"];
@@ -214,21 +248,42 @@ public:
 	}
 };
 
-Ev::Io<void> wait_for_pay_reply(std::shared_ptr<bool> pay_replied,
-				std::size_t retries = 0) {
-	return Ev::lift().then([pay_replied, retries]() {
-		if (*pay_replied)
+Ev::Io<void> wait_for(std::shared_ptr<bool> flag,
+		      std::size_t retries = 0) {
+	return Ev::lift().then([flag, retries]() {
+		if (*flag)
 			return Ev::lift();
 		assert(retries < 100000);
-		return Ev::yield().then([pay_replied, retries]() {
-			return wait_for_pay_reply(pay_replied, retries + 1);
+		return Ev::yield().then([flag, retries]() {
+			return wait_for(flag, retries + 1);
 		});
 	});
 }
 
-} // namespace
+/* Yield a bounded number of times to let async tasks settle, without
+ * requiring a specific flag.  Used for rejection scenarios where the
+ * payer throws internally and no pay_replied flag is ever set.
+ */
+Ev::Io<void> settle(std::size_t remaining = 200) {
+	return Ev::yield().then([remaining]() {
+		if (remaining == 0)
+			return Ev::lift();
+		return settle(remaining - 1);
+	});
+}
 
-int main() {
+struct Scenario {
+	char const* label;
+	std::string expected_hash;       /* PayInvoice.expected_payment_hash  */
+	std::uint64_t expected_amount;   /* PayInvoice.expected_amount_msat   */
+	std::string decode_hash;         /* decode response payment_hash      */
+	std::uint64_t decode_amount;     /* decode response amount_msat       */
+	double decode_created_at;
+	double decode_expiry;
+	bool expect_pay;
+};
+
+int run_scenario(Scenario const& sc) {
 	auto bus = S::Bus();
 	auto payer = Boss::Mod::InvoicePayer(bus);
 
@@ -244,7 +299,15 @@ int main() {
 	auto server_socket = Net::Fd(sockets[0]);
 	auto client_socket = Net::Fd(sockets[1]);
 
-	auto server = MockRpcServer(std::move(server_socket), pay_replied);
+	auto decode_response = make_decode_response(
+		sc.decode_hash, sc.decode_amount,
+		sc.decode_created_at, sc.decode_expiry
+	);
+	auto server = MockRpcServer( std::move(server_socket)
+				   , pay_replied
+				   , decode_response
+				   , sc.expect_pay
+				   );
 	auto rpc = Boss::Mod::Rpc(bus, std::move(client_socket));
 
 	auto client_code = Ev::lift().then([&]() {
@@ -259,7 +322,9 @@ int main() {
 			false
 		});
 	}).then([&]() {
-		return bus.raise(Boss::Msg::PayInvoice{invoice, "", 0});
+		return bus.raise(Boss::Msg::PayInvoice{
+			invoice, sc.expected_hash, sc.expected_amount
+		});
 	});
 
 	auto code = Ev::lift().then([&]() {
@@ -267,7 +332,9 @@ int main() {
 	}).then([&]() {
 		return Ev::concurrent(client_code);
 	}).then([&]() {
-		return wait_for_pay_reply(pay_replied);
+		if (sc.expect_pay)
+			return wait_for(pay_replied);
+		return settle();
 	}).then([&]() {
 		return bus.raise(Boss::Shutdown{});
 	}).then([]() {
@@ -275,7 +342,99 @@ int main() {
 	});
 
 	auto ec = Ev::start(code);
-	assert(*pay_replied);
 	assert(ec == 0);
+
+	if (sc.expect_pay) {
+		assert(*pay_replied);
+	} else {
+		assert(!*pay_replied);
+	}
+	return 0;
+}
+
+} // namespace
+
+int main() {
+	auto const now = double(std::time(nullptr));
+
+	/* 1. No expected hash set — backward-compat happy path.  */
+	run_scenario({ "no-expected-hash (backward compat)"
+		      , ""              /* expected_hash   */
+		      , 0               /* expected_amount */
+		      , GOOD_HASH       /* decode_hash     */
+		      , GOOD_AMOUNT     /* decode_amount   */
+		      , now             /* created_at      */
+		      , 604800          /* expiry          */
+		      , true            /* expect_pay      */
+	});
+
+	/* 2. Matching payment_hash — pay succeeds.  */
+	run_scenario({ "matching payment_hash"
+		      , GOOD_HASH
+		      , 0
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , now
+		      , 604800
+		      , true
+	});
+
+	/* 3. Mismatched payment_hash — pay refused.  */
+	run_scenario({ "mismatched payment_hash"
+		      , std::string(64, '0')   /* wrong hash */
+		      , 0
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , now
+		      , 604800
+		      , false                   /* expect_pay */
+	});
+
+	/* 4. Matching amount — pay succeeds.  */
+	run_scenario({ "matching amount_msat"
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , now
+		      , 604800
+		      , true
+	});
+
+	/* 5. Mismatched amount — pay refused.  */
+	run_scenario({ "mismatched amount_msat"
+		      , ""
+		      , GOOD_AMOUNT
+		      , GOOD_HASH
+		      , GOOD_AMOUNT + 1     /* different amount */
+		      , now
+		      , 604800
+		      , false
+	});
+
+	/* 6. Expired invoice — pay refused.
+	 * created_at + expiry far in the past.
+	 */
+	run_scenario({ "expired invoice"
+		      , GOOD_HASH
+		      , 0
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , 1.0             /* created_at = epoch         */
+		      , 1.0             /* expiry = 1 second          */
+		      , false
+	});
+
+	/* 7. Non-expired invoice with expected_hash — pay succeeds.  */
+	run_scenario({ "non-expired invoice"
+		      , GOOD_HASH
+		      , 0
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , now
+		      , 604800
+		      , true
+	});
+
 	return 0;
 }

--- a/tests/boss/test_invoicepayer_decodepay.cpp
+++ b/tests/boss/test_invoicepayer_decodepay.cpp
@@ -92,25 +92,44 @@ std::string make_decode_response( std::string const& payment_hash
 				, std::uint64_t amount_msat
 				, double created_at
 				, double expiry
+				, bool include_hash = true
+				, bool include_amount = true
+				, bool include_created = true
+				, bool include_expiry = true
 				) {
 	auto os = std::ostringstream();
 	os << R"({
 	   "type": "bolt11 invoice",
-	   "currency": "tb",
+	   "currency": "tb",)";
+	if (include_created) {
+	   os << R"(
 	   "created_at": )"
-	   << created_at << R"(,
+	   << created_at << R"(,)";
+	}
+	if (include_expiry) {
+	   os << R"(
 	   "expiry": )"
-	   << expiry << R"(,
-	   "payee": "0225bbc2a7341993cd592d7b0c185bb8c6359cc1dd1337975c6d41354e4703bf64",
+	   << expiry << R"(,)";
+	}
+	   os << R"(
+	   "payee": "0225bbc2a7341993cd592d7b0c185bb8c6359cc1dd1337975c6d41354e4703bf64",)";
+	if (include_amount) {
+	   os << R"(
 	   "amount_msat": )"
-	   << amount_msat << R"(,
+	   << amount_msat << R"(,)";
+	}
+	   os << R"(
 	   "description": "decode testing",
 	   "min_final_cltv_expiry": 10,
 	   "payment_secret": "d8577cf3c01f0b9b124adee87f552c2b3195db83f4dea30874d5b27d26201e85",
 	   "features": "02024100",
-	   "routes": [],
+	   "routes": [],)";
+	if (include_hash) {
+	   os << R"(
 	   "payment_hash": ")"
-	   << payment_hash << R"(",
+	   << payment_hash << R"(",)";
+	}
+	   os << R"(
 	   "signature": "3045022100e745b9b7fe8133c7385e40561217e4717f7a2868c60d794b160047512c8d3a79022074619d6d2ee5c07b3099ca3684f896886aab04854bfade8f5a0f9014d5418ab6",
 	   "valid": true
 	})";
@@ -304,13 +323,17 @@ Ev::Io<void> wait_for(std::shared_ptr<bool> flag,
 
 struct Scenario {
 	char const* label;
-	std::string expected_hash;       /* PayInvoice.expected_payment_hash  */
-	std::uint64_t expected_amount;   /* PayInvoice.expected_amount_msat   */
-	std::string decode_hash;         /* decode response payment_hash      */
-	std::uint64_t decode_amount;     /* decode response amount_msat       */
+	std::string expected_hash;
+	std::uint64_t expected_amount;
+	std::string decode_hash;
+	std::uint64_t decode_amount;
 	double decode_created_at;
 	double decode_expiry;
 	bool expect_pay;
+	bool include_hash = true;
+	bool include_amount = true;
+	bool include_created = true;
+	bool include_expiry = true;
 };
 
 int run_scenario(Scenario const& sc) {
@@ -332,7 +355,9 @@ int run_scenario(Scenario const& sc) {
 
 	auto decode_response = make_decode_response(
 		sc.decode_hash, sc.decode_amount,
-		sc.decode_created_at, sc.decode_expiry
+		sc.decode_created_at, sc.decode_expiry,
+		sc.include_hash, sc.include_amount,
+		sc.include_created, sc.include_expiry
 	);
 	auto server = MockRpcServer( std::move(server_socket)
 				   , pay_replied
@@ -464,6 +489,45 @@ int main() {
 		      , now
 		      , 604800
 		      , true
+	});
+
+	/* 8. Missing payment_hash in decode — fail-closed, pay refused.  */
+	run_scenario({ "missing payment_hash"
+		      , GOOD_HASH
+		      , 0
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , now
+		      , 604800
+		      , false
+		      , false          /* include_hash = false */
+	});
+
+	/* 9. Missing amount_msat in decode — fail-closed, pay refused.  */
+	run_scenario({ "missing amount_msat"
+		      , ""
+		      , GOOD_AMOUNT
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , now
+		      , 604800
+		      , false
+		      , true           /* include_hash    */
+		      , false          /* include_amount */
+	});
+
+	/* 10. Missing created_at in decode — fail-closed, pay refused.  */
+	run_scenario({ "missing created_at"
+		      , GOOD_HASH
+		      , 0
+		      , GOOD_HASH
+		      , GOOD_AMOUNT
+		      , now
+		      , 604800
+		      , false
+		      , true           /* include_hash    */
+		      , true           /* include_amount  */
+		      , false          /* include_created */
 	});
 
 	return 0;

--- a/tests/boss/test_invoicepayer_decodepay.cpp
+++ b/tests/boss/test_invoicepayer_decodepay.cpp
@@ -259,7 +259,7 @@ int main() {
 			false
 		});
 	}).then([&]() {
-		return bus.raise(Boss::Msg::PayInvoice{invoice});
+		return bus.raise(Boss::Msg::PayInvoice{invoice, "", 0});
 	});
 
 	auto code = Ev::lift().then([&]() {

--- a/tests/boss/test_invoicepayer_decodepay.cpp
+++ b/tests/boss/test_invoicepayer_decodepay.cpp
@@ -123,6 +123,7 @@ private:
 	Jsmn::Parser parser;
 	std::deque<Jsmn::Object> requests;
 	std::shared_ptr<bool> pay_replied;
+	std::shared_ptr<bool> server_done;
 	std::string decode_response;
 	bool expect_pay;
 
@@ -151,6 +152,38 @@ private:
 			for (auto& p : parsed)
 				requests.push_back(std::move(p));
 			return read_request(retries + 1);
+		});
+	}
+
+	Ev::Io<Jsmn::Object> read_request_bounded(std::size_t max_retries
+						  , std::size_t retries = 0) {
+		return Ev::yield().then([this]() {
+			if (requests.empty())
+				return Ev::lift(Jsmn::Object());
+			auto req = std::move(requests.front());
+			requests.pop_front();
+			return Ev::lift(std::move(req));
+		}).then([this, max_retries, retries](Jsmn::Object req) {
+			if (!req.is_null())
+				return Ev::lift(std::move(req));
+			if (retries >= max_retries)
+				return Ev::lift(Jsmn::Object());
+
+			char buf[512];
+			auto rd = ssize_t();
+			do {
+				rd = read(socket.get(), buf, sizeof(buf));
+			} while (rd < 0 && errno == EINTR);
+			if (rd < 0 && (errno == EWOULDBLOCK || errno == EAGAIN))
+				return read_request_bounded(max_retries
+							   , retries + 1);
+			if (rd <= 0)
+				return Ev::lift(Jsmn::Object());
+
+			auto parsed = parser.feed(std::string(buf, std::size_t(rd)));
+			for (auto& p : parsed)
+				requests.push_back(std::move(p));
+			return read_request_bounded(max_retries, retries + 1);
 		});
 	}
 
@@ -198,12 +231,14 @@ private:
 public:
 	MockRpcServer( Net::Fd socket_
 		     , std::shared_ptr<bool> pay_replied_
+		     , std::shared_ptr<bool> server_done_
 		     , std::string decode_response_
 		     , bool expect_pay_
 		     ) : socket(std::move(socket_))
 		       , parser()
 		       , requests()
 		       , pay_replied(std::move(pay_replied_))
+		       , server_done(std::move(server_done_))
 		       , decode_response(std::move(decode_response_))
 		       , expect_pay(expect_pay_)
 	{
@@ -223,10 +258,14 @@ public:
 			assert(std::string(params["string"]) == invoice);
 			return reply_result(id, decode_response);
 		}).then([this, invoice]() {
-			if (!expect_pay)
-				/* Payer should reject the invoice; no pay
-				 * request will arrive.  */
-				return Ev::lift();
+			if (!expect_pay) {
+				return read_request_bounded(500).then(
+					[this](Jsmn::Object req) {
+					if (!req.is_null())
+						*pay_replied = true;
+					return Ev::lift();
+				});
+			}
 			return read_request().then([this, invoice](Jsmn::Object req) {
 				auto id = assert_method(req, "pay");
 				auto params = req["params"];
@@ -244,6 +283,9 @@ public:
 				*pay_replied = true;
 				return Ev::lift();
 			});
+		}).then([this]() {
+			*server_done = true;
+			return Ev::lift();
 		});
 	}
 };
@@ -257,18 +299,6 @@ Ev::Io<void> wait_for(std::shared_ptr<bool> flag,
 		return Ev::yield().then([flag, retries]() {
 			return wait_for(flag, retries + 1);
 		});
-	});
-}
-
-/* Yield a bounded number of times to let async tasks settle, without
- * requiring a specific flag.  Used for rejection scenarios where the
- * payer throws internally and no pay_replied flag is ever set.
- */
-Ev::Io<void> settle(std::size_t remaining = 200) {
-	return Ev::yield().then([remaining]() {
-		if (remaining == 0)
-			return Ev::lift();
-		return settle(remaining - 1);
 	});
 }
 
@@ -292,6 +322,7 @@ int run_scenario(Scenario const& sc) {
 	auto signer = DummySigner();
 	auto db = Sqlite3::Db(":memory:");
 	auto pay_replied = std::make_shared<bool>(false);
+	auto server_done = std::make_shared<bool>(false);
 
 	int sockets[2];
 	auto sockres = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
@@ -305,6 +336,7 @@ int run_scenario(Scenario const& sc) {
 	);
 	auto server = MockRpcServer( std::move(server_socket)
 				   , pay_replied
+				   , server_done
 				   , decode_response
 				   , sc.expect_pay
 				   );
@@ -332,9 +364,7 @@ int run_scenario(Scenario const& sc) {
 	}).then([&]() {
 		return Ev::concurrent(client_code);
 	}).then([&]() {
-		if (sc.expect_pay)
-			return wait_for(pay_replied);
-		return settle();
+		return wait_for(server_done);
 	}).then([&]() {
 		return bus.raise(Boss::Shutdown{});
 	}).then([]() {


### PR DESCRIPTION
## Summary

Adds invoice `payment_hash` verification to `InvoicePayer`, closing the gap described in #329.

## Problem

CLBOSS verifies the redeemScript structure thoroughly (match_lockscript, preimage hash, pubkeys, timeout, lockup amount) but does **not** verify that the Lightning invoice's `payment_hash` matches the preimage hash it generated. This means a network attacker who can modify Boltz API responses can substitute the invoice, redirecting the Lightning payment to their own node.

This check is:

- Required by [Boltz's own documentation](https://api.docs.boltz.exchange/dont-trust-verify.html)
- Implemented by Electrum (`if lnaddr.paymenthash != payment_hash: raise`)
- Implemented by boltz-web-app (`sha256(preimage) == invoice.payment_hash`)
- Implemented by boltz-client Go (`SwapTree.Check()`)
- **Missing in CLBOSS**

## Changes

**InvoicePayer** (`Boss/Mod/InvoicePayer.cpp`):
- Fail-closed validation: when `expected_payment_hash` is set, the decode response MUST contain `payment_hash` (throws if missing)
- Same fail-closed for `expected_amount_msat` / `amount_msat`
- Invoice expiry check uses CLN's `created_at` field (not `timestamp`)
- Throws `Jsmn::TypeError` on mismatch, matching the existing validity-check pattern

**SwapManager** (`Boss/Mod/SwapManager.cpp`):
- Passes `swap->hash` and swap amount (in millisatoshis) through the `PayInvoice` message
- Reads persisted amount via `Ln::Amount::msat()` (DB stores msat)

**SwapSetupHandler** (`Boltz/Detail/SwapSetupHandler.cpp`):
- RedeemScript byte-compare via extracted `construct_redeemscript()` pure function

**Tests**:
- `test_construct_redeemscript`: round-trip against known-good script vector
- `test_invoicepayer_decodepay`: 7 scenarios — hash match/mismatch, amount match/mismatch, expired invoice, backward-compat, non-expired with hash check
- Rejection scenarios use bounded reads to detect any unexpected `pay` request

## Backward compatibility

- `expected_payment_hash` defaults to empty string
- Non-swap callers of `PayInvoice` are unaffected (empty hash = skip check)
- No new dependencies — reuses CLN's existing `decode` RPC

Closes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Validate invoice `payment_hash`, amount, and expiry before payment. Preserve backward compatibility when no expected hash is provided.
- Pass the expected swap hash and amount through `SwapManager` and `PayInvoice`. Use CLN `created_at` for expiry validation.
- Reconstruct and byte-compare the swap redeemScript. Add tests for invoice validation, redeemScript construction, and swap setup validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->