### PR TITLE
SwapManager: watchdog for wedged address/invoice loops

### DIFF
--- a/Boss/Mod/SwapManager.cpp
+++ b/Boss/Mod/SwapManager.cpp
@@ -22,6 +22,7 @@
 #include"Boss/random_engine.hpp"
 #include"Ev/Io.hpp"
 #include"Ev/foreach.hpp"
+#include"Ev/now.hpp"
 #include"Ev/yield.hpp"
 #include"S/Bus.hpp"
 #include"Sqlite3.hpp"
@@ -40,7 +41,12 @@ private:
 	S::Bus& bus;
 	Sqlite3::Db db;
 	bool getting_address;
+	double getting_address_start;
 	bool getting_invoice;
+	double getting_invoice_start;
+	/* Stalled-loop watchdog window; see check_stall.  Settable
+	 * for tests.  */
+	double stall_timeout_secs;
 
 public:
 	Impl() =delete;
@@ -51,8 +57,15 @@ public:
 	Impl( S::Bus& bus_
 	    ) : bus(bus_)
 	      , getting_address(false)
+	      , getting_address_start(0.0)
 	      , getting_invoice(false)
+	      , getting_invoice_start(0.0)
+	      , stall_timeout_secs(1800.0)
 	      { start(); }
+
+	void set_stall_timeout_secs(double secs) {
+		stall_timeout_secs = secs;
+	}
 
 private:
 	/* /!\ db column 'state', do not change numbers!  */
@@ -212,7 +225,15 @@ private:
 	std::queue<Uuid> needs_invoice;
 
 	Ev::Io<void> on_periodic() {
-		return Ev::lift().then([this]() {
+		return check_stall( "address"
+				  , getting_address
+				  , getting_address_start
+				  ).then([this]() {
+			return check_stall( "invoice"
+					  , getting_invoice
+					  , getting_invoice_start
+					  );
+		}).then([this]() {
 			return load_queue( needs_address
 					 , NeedsOnchainAddress
 					 ).then([this]() {
@@ -259,11 +280,34 @@ private:
 		});
 	}
 
+	/* The getting_* flags serialize their loops, but a loop's
+	 * continuation can arrive via a bus response that may never
+	 * come (a newaddr or swap-provider chain dying mid-flight),
+	 * leaving the flag set and the loop dead for the process
+	 * lifetime -- every later tick would no-op silently.  Clear
+	 * a flag stuck longer than stall_timeout_secs so the same
+	 * tick restarts the loop and retries the queue front.  */
+	Ev::Io<void> check_stall( char const* what
+				, bool& flag
+				, double& start
+				) {
+		if (!flag || Ev::now() - start < stall_timeout_secs)
+			return Ev::lift();
+		flag = false;
+		return Boss::log( bus, Warn
+				, "SwapManager: %s loop stalled for "
+				  "%.0f minutes; restarting it."
+				, what
+				, (Ev::now() - start) / 60.0
+				);
+	}
+
 	/* Processing of items in needs-address.  */
 	Ev::Io<void> process_needs_address() {
 		if (getting_address)
 			return Ev::lift();
 		getting_address = true;
+		getting_address_start = Ev::now();
 		return loop_needs_address();
 	}
 	Ev::Io<void> loop_needs_address() {
@@ -316,7 +360,15 @@ private:
 		});
 	}
 	Ev::Io<void> on_response_newaddr(std::string n_address) {
-		assert(getting_address);
+		/* A response landing after check_stall reset the loop
+		 * has no claim on the queue front; drop it -- an
+		 * unused address is harmless, and the restarted loop
+		 * requests its own.  */
+		if (!getting_address || needs_address.empty())
+			return Boss::log( bus, Debug
+					, "SwapManager: dropping late "
+					  "newaddr response."
+					);
 		auto address = std::make_shared<std::string>(
 			std::move(n_address)
 		);
@@ -380,6 +432,7 @@ private:
 		if (getting_invoice)
 			return Ev::lift();
 		getting_invoice = true;
+		getting_invoice_start = Ev::now();
 		return loop_needs_invoice();
 	}
 
@@ -490,6 +543,14 @@ private:
 	}
 	/* On swap creation.  */
 	Ev::Io<void> on_swap_creation(Msg::SwapCreation const& s) {
+		/* Same staleness rule as newaddr responses: with no
+		 * live invoice round, this response is from a round
+		 * check_stall already abandoned.  */
+		if (!getting_invoice || needs_invoice.empty())
+			return Boss::log( bus, Debug
+					, "SwapManager: dropping late "
+					  "swap-creation response."
+					);
 		if (!s.success) {
 			/* Remove a quotation and try again.  */
 			quotations.pop_back();
@@ -1175,5 +1236,9 @@ SwapManager::~SwapManager() =default;
 SwapManager::SwapManager(S::Bus& bus
 			) : pimpl(Util::make_unique<Impl>(bus))
 			  { }
+
+void SwapManager::set_stall_timeout_secs(double secs) {
+	pimpl->set_stall_timeout_secs(secs);
+}
 
 }}

--- a/Boss/Mod/SwapManager.hpp
+++ b/Boss/Mod/SwapManager.hpp
@@ -27,6 +27,9 @@ public:
 
 	explicit
 	SwapManager(S::Bus& bus);
+
+	/* Test seam: shrink the stalled-loop watchdog window.  */
+	void set_stall_timeout_secs(double secs);
 };
 
 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- A swap whose newaddr or swap-provider conversation died
+  mid-flight could wedge SwapManager for the process lifetime:
+  the flag serializing each processing loop was only cleared when
+  the loop's queue drained, and the response that would have
+  advanced it sometimes never arrives.  The periodic tick now
+  clears a flag stuck longer than 30 minutes and restarts the
+  loop; the previous remedy was restarting Core Lightning.
+
 ## [0.16.3] - 2026-08-18: "Tougher Than the Race"
 
 ### Security

--- a/tests/boss/test_swapmanager.cpp
+++ b/tests/boss/test_swapmanager.cpp
@@ -12,6 +12,7 @@
 #include"Boss/Msg/SwapCreation.hpp"
 #include"Boss/Msg/SwapRequest.hpp"
 #include"Boss/Msg/SwapResponse.hpp"
+#include"Boss/Msg/Timer10Minutes.hpp"
 #include"Ev/Io.hpp"
 #include"Ev/foreach.hpp"
 #include"Ev/start.hpp"
@@ -49,11 +50,18 @@ public:
 class MockNewaddr {
 private:
 	std::queue<std::string> addresses;
+	bool swallow_next_flag = false;
 public:
 	MockNewaddr(S::Bus& bus) {
 		bus.subscribe<Boss::Msg::RequestNewaddr
 			     >([ this, &bus
 			       ](Boss::Msg::RequestNewaddr const& r) {
+			/* Simulate the newaddr chain dying mid-flight:
+			 * no response ever arrives.  */
+			if (swallow_next_flag) {
+				swallow_next_flag = false;
+				return Ev::lift();
+			}
 			assert(!addresses.empty());
 			auto addr = addresses.front();
 			addresses.pop();
@@ -65,6 +73,7 @@ public:
 	void add(std::string addr) {
 		addresses.emplace(std::move(addr));
 	}
+	void swallow_next() { swallow_next_flag = true; }
 	bool empty() const { return addresses.empty(); }
 };
 struct MockProvider {};
@@ -338,6 +347,56 @@ Ev::Io<void> test_simple() {
 	});
 }
 
+/* A newaddr chain that never responds must not wedge the address
+ * loop forever: the periodic tick's watchdog clears the stuck
+ * serialization flag and the restarted loop retries the swap.  */
+Ev::Io<void> test_stall_recovery() {
+
+	Uuid uuid = Uuid::random();
+
+	return Ev::lift().then([&, uuid]() {
+		/* Make the watchdog fire on the next tick.  */
+		swapper.set_stall_timeout_secs(0.0);
+
+		/* The address request will get no response, wedging
+		 * the loop with its flag set.  */
+		addresses.swallow_next();
+		return requester.start_swap( uuid
+					   , Ln::Amount::btc(0.001)
+					   , Ln::Amount::btc(0.012)
+					   );
+	}).then([&]() {
+		return wait();
+	}).then([&]() {
+		/* Stock the mocks for the retry, then tick: the
+		 * watchdog resets the flag and the restarted loop
+		 * re-requests an address.  */
+		addresses.add("address2");
+		quotations.add({Ln::Amount::sat(1000)});
+		swapsetups.add({"address2", true, "invoice2"
+			       , Sha256::Hash("ec8103d3f57a561fd213bf6bb45b2cd0e1b37738232c7d1fd13b1a7729bf0983")
+			       , 23456
+			       });
+		return bus.raise(Boss::Msg::Timer10Minutes{});
+	}).then([&]() {
+		return wait();
+	}).then([&]() {
+		assert(addresses.empty());
+		assert(quotations.empty());
+		assert(swapsetups.okay());
+
+		return onchain.listfunds({ { "address2"
+					   , Ln::Amount::sat(12100)
+					   }
+					 });
+	}).then([&]() {
+		return wait();
+	}).then([&, uuid]() {
+		requester.expect_finished(uuid, true);
+		return Ev::lift();
+	});
+}
+
 }
 
 /*-----------------------------------------------------------------------------
@@ -349,6 +408,8 @@ int main() {
 		return bus.raise(Boss::Msg::DbResource{db});
 	}).then([&]() {
 		return test_simple();
+	}).then([&]() {
+		return test_stall_recovery();
 	}).then([&]() {
 		return Ev::lift(0);
 	});


### PR DESCRIPTION
Fixes #333.

SwapManager serializes its address and invoice loops with
in-memory flags cleared only when the loop's queue drains.  Each
loop's continuation arrives via a bus response -- the newaddr
reply, or the swap provider's quotation/creation chain -- that
can simply never arrive; the flag then stays set for the process
lifetime and every later 10-minute tick no-ops silently.  Present
since the original 2020 SwapManager; recovery previously required
restarting Core Lightning.

The periodic tick now clears a flag stuck longer than 30 minutes,
logs at Warn, and restarts the loop in the same tick, retrying
the queued swap.  Responses landing after such a reset are
dropped with a Debug log instead of asserting or touching a queue
front they no longer own.  The watchdog window has a test seam
(set_stall_timeout_secs).

VALIDATION NOTICE

This change is unit-tested but NOT live-validated.
test_stall_recovery wedges the address loop with a swallowed
newaddr response and asserts a periodic tick recovers the swap
end to end; the full suite is green.  Live validation requires a
reachable swap provider, and the Boltz service the swap subsystem
targets is currently down, so the watchdog cannot yet be
exercised against a real conversation.  Until then the practical
risk is bounded: the watchdog only acts on a flag that has been
stuck for over 30 minutes, so on a healthy loop it never fires,
and that no-trigger path is covered by the existing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a `SwapManager` watchdog for stalled address and invoice processing loops.
- Reset stalled loops after the configurable timeout, log the recovery, ignore late responses, and retry queued swaps.
- Added unit coverage for address-loop recovery and documented the fix in `CHANGELOG.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->