### PR TITLE
XRebalancer: make the grant's weight a setting, and fade the grant out over it

### DIFF
--- a/Boss/Mod/XRebalancer.cpp
+++ b/Boss/Mod/XRebalancer.cpp
@@ -70,10 +70,12 @@ auto constexpr default_drain_band = double(75.0);
 auto constexpr default_maxparts = double(80.0);
 
 /* Strictness benders, both neutral by default.  grant credits every
- * channeled peer an assumed prior of grant ppm on one capacity-turn
- * of volume; gain multiplies the joined net rate.  The result is
- * what clboss-xrebalance-view shows as InAdjPpm/OutAdjPpm, beside
- * the raw InNetPpm/OutNetPpm.  */
+ * channeled peer an assumed prior of grant ppm on one rebalance's
+ * worth of volume per side: fill-loc percent of its capacity on the
+ * out side (one fill), 100 - drain-loc percent on the in side (one
+ * drain); gain multiplies the joined net rate.  The result is what
+ * clboss-xrebalance-view shows as InAdjPpm/OutAdjPpm, beside the
+ * raw InNetPpm/OutNetPpm.  */
 auto constexpr default_grant = double(0.0);
 auto constexpr default_gain = double(1.0);
 
@@ -112,7 +114,7 @@ private:
 	double fill_band;
 	double drain_band;
 	std::uint32_t maxparts;   /* MCF split cap (integer count) */
-	double grant_ppm;         /* assumed prior rate (ppm of a capacity-turn) */
+	double grant_ppm;         /* assumed prior rate (ppm, weighted by one rebalance) */
 	double gain;              /* NetPpm multiplier */
 	bool floor_auto;   /* floor option set to "auto" (sweep) */
 	bool started;
@@ -219,11 +221,13 @@ private:
 				"Assumed prior earnings rate (ppm), credited "
 				"to every channeled peer on both sides as if "
 				"it had already earned that rate on one "
-				"capacity-turn of volume.  Admits peers with "
-				"no track record at exactly this rate; "
-				"expenditures spend the credit down (subsidy "
-				"per peer bounded by grant x capacity) and "
-				"real volume dilutes it toward the measured "
+				"rebalance's worth of volume: fill-loc percent "
+				"of its capacity on the out side, 100 - "
+				"drain-loc percent on the in side.  Admits "
+				"peers with no track record at exactly this "
+				"rate; expenditures spend the credit down (one "
+				"fill or drain to the band edge at grant ppm) "
+				"and real volume dilutes it toward the measured "
 				"rate.  0 = record-only (default).")
 			     + manifest_option(opt_gain, default_gain,
 				"Multiplier (> 0) on each side's net earnings "
@@ -533,24 +537,34 @@ private:
 		return db.transact().then([ this, cutoff, chans, demand_scid
 					  ](Sqlite3::Tx tx) {
 			auto net = std::make_shared<std::map<Ln::NodeId, NetPpm>>();
-			/* Per-peer capacity (msat): grant's credit base and
-			 * notional volume.  */
+			/* Per-peer capacity (msat); one rebalance's worth
+			 * of it, per side, is grant's credit base and
+			 * notional volume: a fill moves up to fill_band
+			 * percent in (the out side's credit), a drain moves
+			 * up to 100 - drain_band percent out (the in
+			 * side's).  */
 			auto cap_msat = std::map<Ln::NodeId, double>();
 			for (auto const& c : *chans)
 				cap_msat[c.node] += double(c.cap_sat) * 1000.0;
+			auto w_in = [this](double cm) {
+				return cm * (100.0 - drain_band) / 100.0;
+			};
+			auto w_out = [this](double cm) {
+				return cm * fill_band / 100.0;
+			};
 			/* Join one side.  Strict form is (e - x) / f over
 			 * f > 0.  With grant, credit the peer as if it had
-			 * already earned grant ppm on one capacity-turn:
-			 * (e - x + cap*grant/1e6) / (f + cap) -- a fresh
-			 * peer reads exactly grant, expenditures spend the
-			 * credit down, real volume dilutes it toward the
-			 * measured rate.  gain scales the result either
-			 * way.  */
+			 * already earned grant ppm on w, that side's
+			 * rebalance volume: (e - x + w*grant/1e6) / (f + w)
+			 * -- a fresh peer reads exactly grant, the credit
+			 * covers one move to the band edge at grant ppm,
+			 * and real volume dilutes it toward the measured
+			 * rate.  gain scales the result either way.  */
 			auto joined = [this]( double e, double x, double f
-					    , double cm
+					    , double w
 					    , bool& has, double& ppm
 					    ) {
-				auto g = grant_ppm > 0.0 ? cm : 0.0;
+				auto g = grant_ppm > 0.0 ? w : 0.0;
 				if (!(f + g > 0.0))
 					return;
 				has = true;
@@ -582,8 +596,9 @@ private:
 				if (ci != cap_msat.end())
 					cm = ci->second;
 				auto p = NetPpm();
-				joined(in_e, in_x, in_f, cm, p.has_in, p.in_net);
-				joined(out_e, out_x, out_f, cm,
+				joined(in_e, in_x, in_f, w_in(cm),
+				       p.has_in, p.in_net);
+				joined(out_e, out_x, out_f, w_out(cm),
 				       p.has_out, p.out_net);
 				(*net)[node] = p;
 			}
@@ -594,9 +609,9 @@ private:
 					if (net->count(ce.first))
 						continue;
 					auto p = NetPpm();
-					joined(0.0, 0.0, 0.0, ce.second,
+					joined(0.0, 0.0, 0.0, w_in(ce.second),
 					       p.has_in, p.in_net);
-					joined(0.0, 0.0, 0.0, ce.second,
+					joined(0.0, 0.0, 0.0, w_out(ce.second),
 					       p.has_out, p.out_net);
 					(*net)[ce.first] = p;
 				}

--- a/Boss/Mod/XRebalancer.cpp
+++ b/Boss/Mod/XRebalancer.cpp
@@ -51,6 +51,7 @@ auto const opt_fill_loc = std::string("clboss-xrebalance-fill-loc");
 auto const opt_drain_loc = std::string("clboss-xrebalance-drain-loc");
 auto const opt_maxparts = std::string("clboss-xrebalance-maxparts");
 auto const opt_grant = std::string("clboss-xrebalance-grant");
+auto const opt_grant_weight = std::string("clboss-xrebalance-grant-weight");
 auto const opt_gain = std::string("clboss-xrebalance-gain");
 
 auto constexpr default_per_hour = double(24.0);
@@ -70,13 +71,12 @@ auto constexpr default_drain_band = double(75.0);
 auto constexpr default_maxparts = double(80.0);
 
 /* Strictness benders, both neutral by default.  grant credits every
- * channeled peer an assumed prior of grant ppm on one rebalance's
- * worth of volume per side: fill-loc percent of its capacity on the
- * out side (one fill), 100 - drain-loc percent on the in side (one
- * drain); gain multiplies the joined net rate.  The result is what
- * clboss-xrebalance-view shows as InAdjPpm/OutAdjPpm, beside the
- * raw InNetPpm/OutNetPpm.  */
+ * channeled peer an assumed prior of grant ppm on grant_weight
+ * percent of its capacity, both sides; gain multiplies the joined
+ * net rate.  The result is what clboss-xrebalance-view shows as
+ * InAdjPpm/OutAdjPpm, beside the raw InNetPpm/OutNetPpm.  */
 auto constexpr default_grant = double(0.0);
+auto constexpr default_grant_weight = double(25.0);
 auto constexpr default_gain = double(1.0);
 
 auto constexpr paused_poll_secs = double(60.0);
@@ -114,7 +114,8 @@ private:
 	double fill_band;
 	double drain_band;
 	std::uint32_t maxparts;   /* MCF split cap (integer count) */
-	double grant_ppm;         /* assumed prior rate (ppm, weighted by one rebalance) */
+	double grant_ppm;         /* assumed prior rate (ppm) */
+	double grant_weight;      /* grant's notional volume, percent of capacity */
 	double gain;              /* NetPpm multiplier */
 	bool floor_auto;   /* floor option set to "auto" (sweep) */
 	bool started;
@@ -168,6 +169,7 @@ private:
 		drain_band = default_drain_band;
 		maxparts = std::uint32_t(default_maxparts);
 		grant_ppm = default_grant;
+		grant_weight = default_grant_weight;
 		gain = default_gain;
 		started = false;
 		in_flight = false;
@@ -220,15 +222,18 @@ private:
 			     + manifest_option(opt_grant, default_grant,
 				"Assumed prior earnings rate (ppm), credited "
 				"to every channeled peer on both sides as if "
-				"it had already earned that rate on one "
-				"rebalance's worth of volume: fill-loc percent "
-				"of its capacity on the out side, 100 - "
-				"drain-loc percent on the in side.  Admits "
+				"it had already earned that rate on "
+				"grant-weight percent of its capacity.  Admits "
 				"peers with no track record at exactly this "
-				"rate; expenditures spend the credit down (one "
-				"fill or drain to the band edge at grant ppm) "
-				"and real volume dilutes it toward the measured "
+				"rate; expenditures spend the credit down and "
+				"real volume dilutes it toward the measured "
 				"rate.  0 = record-only (default).")
+			     + manifest_option(opt_grant_weight,
+				default_grant_weight,
+				"Volume the grant is assumed earned on, as a "
+				"percent of the peer's capacity, both sides.  "
+				"Sets how much record a peer needs before its "
+				"own rate outweighs the grant.  Default 25.")
 			     + manifest_option(opt_gain, default_gain,
 				"Multiplier (> 0) on each side's net earnings "
 				"rate, before candidacy, floor, and maxfee "
@@ -338,6 +343,7 @@ private:
 		else if (o.name == opt_fill_loc)   target = &fill_band;
 		else if (o.name == opt_drain_loc)  target = &drain_band;
 		else if (o.name == opt_grant)      target = &grant_ppm;
+		else if (o.name == opt_grant_weight) target = &grant_weight;
 		else if (o.name == opt_gain)       target = &gain;
 		else return Ev::lift();
 
@@ -358,7 +364,7 @@ private:
 					, o.name.c_str(), s.c_str()
 					);
 		}
-		if (o.name == opt_gain) {
+		if (o.name == opt_gain || o.name == opt_grant_weight) {
 			if (!(v > 0.0)) {
 				o.reject(o.name + ": must be > 0");
 				return Boss::log( bus, Error
@@ -537,34 +543,25 @@ private:
 		return db.transact().then([ this, cutoff, chans, demand_scid
 					  ](Sqlite3::Tx tx) {
 			auto net = std::make_shared<std::map<Ln::NodeId, NetPpm>>();
-			/* Per-peer capacity (msat); one rebalance's worth
-			 * of it, per side, is grant's credit base and
-			 * notional volume: a fill moves up to fill_band
-			 * percent in (the out side's credit), a drain moves
-			 * up to 100 - drain_band percent out (the in
-			 * side's).  */
+			/* Per-peer capacity (msat); grant_weight percent of
+			 * it is grant's credit base and notional volume.  */
 			auto cap_msat = std::map<Ln::NodeId, double>();
 			for (auto const& c : *chans)
 				cap_msat[c.node] += double(c.cap_sat) * 1000.0;
-			auto w_in = [this](double cm) {
-				return cm * (100.0 - drain_band) / 100.0;
-			};
-			auto w_out = [this](double cm) {
-				return cm * fill_band / 100.0;
-			};
 			/* Join one side.  Strict form is (e - x) / f over
 			 * f > 0.  With grant, credit the peer as if it had
-			 * already earned grant ppm on w, that side's
-			 * rebalance volume: (e - x + w*grant/1e6) / (f + w)
-			 * -- a fresh peer reads exactly grant, the credit
-			 * covers one move to the band edge at grant ppm,
-			 * and real volume dilutes it toward the measured
-			 * rate.  gain scales the result either way.  */
+			 * already earned grant ppm on w = cap * grant_weight
+			 * / 100: (e - x + w*grant/1e6) / (f + w) -- a fresh
+			 * peer reads exactly grant, expenditures spend the
+			 * credit down, and real volume dilutes it toward
+			 * the measured rate.  gain scales the result either
+			 * way.  */
 			auto joined = [this]( double e, double x, double f
-					    , double w
+					    , double cm
 					    , bool& has, double& ppm
 					    ) {
-				auto g = grant_ppm > 0.0 ? w : 0.0;
+				auto g = grant_ppm > 0.0
+				       ? cm * grant_weight / 100.0 : 0.0;
 				if (!(f + g > 0.0))
 					return;
 				has = true;
@@ -596,9 +593,8 @@ private:
 				if (ci != cap_msat.end())
 					cm = ci->second;
 				auto p = NetPpm();
-				joined(in_e, in_x, in_f, w_in(cm),
-				       p.has_in, p.in_net);
-				joined(out_e, out_x, out_f, w_out(cm),
+				joined(in_e, in_x, in_f, cm, p.has_in, p.in_net);
+				joined(out_e, out_x, out_f, cm,
 				       p.has_out, p.out_net);
 				(*net)[node] = p;
 			}
@@ -609,9 +605,9 @@ private:
 					if (net->count(ce.first))
 						continue;
 					auto p = NetPpm();
-					joined(0.0, 0.0, 0.0, w_in(ce.second),
+					joined(0.0, 0.0, 0.0, ce.second,
 					       p.has_in, p.in_net);
-					joined(0.0, 0.0, 0.0, w_out(ce.second),
+					joined(0.0, 0.0, 0.0, ce.second,
 					       p.has_out, p.out_net);
 					(*net)[ce.first] = p;
 				}
@@ -712,7 +708,8 @@ private:
 	std::string bender_note() const {
 		auto os = std::ostringstream();
 		if (grant_ppm > 0.0)
-			os << ", grant " << grant_ppm;
+			os << ", grant " << grant_ppm
+			   << " on " << grant_weight << "%";
 		if (gain != 1.0)
 			os << ", gain " << gain;
 		return os.str();

--- a/Makefile.am
+++ b/Makefile.am
@@ -638,6 +638,7 @@ TESTS = \
 	tests/boss/test_setconfighandler \
 	tests/boss/test_xrebalancepartmonitor \
 	tests/boss/test_xrebalancer \
+	tests/boss/test_xrebalancer_grant \
 	tests/boss/test_xrebalancer_plugin \
 	tests/boss/test_peerjudge_algo \
 	tests/boss/test_peerjudge_datagatherer \

--- a/README.md
+++ b/README.md
@@ -685,9 +685,11 @@ All of the following are *dynamic* (`setconfig`) options:
   default.
 * `clboss-xrebalance-grant` — assumed prior earnings rate (ppm),
   credited to every channeled peer as if already earned on one
-  capacity-turn of volume; admits peers with no track record at that
-  rate, and real volume dilutes the credit toward the measured rate.
-  Default `0` (record-only).
+  rebalance's worth of volume: `clboss-xrebalance-fill-loc` percent
+  of its capacity on the out side, 100 minus
+  `clboss-xrebalance-drain-loc` percent on the in side; admits peers
+  with no track record at that rate, and real volume dilutes the
+  credit toward the measured rate.  Default `0` (record-only).
 * `clboss-xrebalance-gain` — multiplier on the measured earnings
   rates before candidacy and pricing; above `1` accepts routes
   costing up to gain times the measured rate, below `1` only routes

--- a/README.md
+++ b/README.md
@@ -684,12 +684,14 @@ All of the following are *dynamic* (`setconfig`) options:
   with it; for example, 30 seconds has been enough with the
   default.
 * `clboss-xrebalance-grant` — assumed prior earnings rate (ppm),
-  credited to every channeled peer as if already earned on one
-  rebalance's worth of volume: `clboss-xrebalance-fill-loc` percent
-  of its capacity on the out side, 100 minus
-  `clboss-xrebalance-drain-loc` percent on the in side; admits peers
-  with no track record at that rate, and real volume dilutes the
-  credit toward the measured rate.  Default `0` (record-only).
+  credited to every channeled peer as if already earned on
+  `clboss-xrebalance-grant-weight` percent of its capacity; admits
+  peers with no track record at that rate, and real volume dilutes
+  the credit toward the measured rate.  Default `0` (record-only).
+* `clboss-xrebalance-grant-weight` — the volume the grant is assumed
+  earned on, as a percent of the peer's capacity, both sides; sets
+  how much record a peer needs before its own rate outweighs the
+  grant.  Default `25`.
 * `clboss-xrebalance-gain` — multiplier on the measured earnings
   rates before candidacy and pricing; above `1` accepts routes
   costing up to gain times the measured rate, below `1` only routes

--- a/contrib/clboss-xrebalance-view
+++ b/contrib/clboss-xrebalance-view
@@ -138,6 +138,7 @@ def read_live_config(lightning_dir, network_option):
         ("route_cost_floor", "clboss-xrebalance-route-cost-floor"),
         ("maxparts", "clboss-xrebalance-maxparts"),
         ("grant", "clboss-xrebalance-grant"),
+        ("grant_weight", "clboss-xrebalance-grant-weight"),
         ("gain", "clboss-xrebalance-gain"),
     ):
         v = val(opt)
@@ -181,14 +182,13 @@ def safe_ppm(numerator_msat, denominator_msat):
     return (numerator_msat * 1_000_000) / denominator_msat
 
 
-def adjusted_net_ppm(net_msat, fwd_msat, move_msat, grant, gain):
+def adjusted_net_ppm(net_msat, fwd_msat, grant_msat, grant, gain):
     """The AdjPpm the driver joins for one side: strict (net / fwd) when
     grant is 0, else the peer credited an assumed prior of grant ppm on
-    move_msat, that side's rebalance volume (cap * fill-loc / 100 on
-    the out side, cap * (100 - drain-loc) / 100 on the in side) --
-    (net + w*grant/1e6) / (fwd + w) -- and gain scales the result either
-    way.  Mirrors XRebalancer's joined()."""
-    g_vol = move_msat if grant > 0 else 0
+    grant_msat, the grant's notional volume (cap * grant-weight / 100)
+    -- (net + w*grant/1e6) / (fwd + w) -- and gain scales the result
+    either way.  Mirrors XRebalancer's joined()."""
+    g_vol = grant_msat if grant > 0 else 0
     denom = fwd_msat + g_vol
     if denom <= 0:
         return None
@@ -355,8 +355,8 @@ def pad_string(s, width):
     return s + " " * (width - wcswidth(s))
 
 
-def compute_row(channel, peer, window_days, peer_cap_msat, fill_loc,
-                drain_loc, grant, gain):
+def compute_row(channel, peer, window_days, peer_cap_msat, grant_weight,
+                grant, gain):
     cap_msat = channel.get("total_msat", 0) or 0
     to_us_msat = channel.get("to_us_msat", 0) or 0
     pct_local = (100.0 * to_us_msat / cap_msat) if cap_msat > 0 else 0.0
@@ -375,18 +375,18 @@ def compute_row(channel, peer, window_days, peer_cap_msat, fill_loc,
     in_exp = peer.get("in_expenditures", 0)
     in_net = in_earn - in_exp
     in_net_ppm = safe_ppm(in_net, in_fwd)
-    # grant's notional volume per side: one drain (in) or one fill (out)
-    # of the peer's capacity, to the band edge.
-    in_move = peer_cap_msat * (100.0 - drain_loc) / 100.0
-    in_adj_ppm = adjusted_net_ppm(in_net, in_fwd, in_move, grant, gain)
+    # grant's notional volume, grant-weight percent of the peer's
+    # capacity, the same on both sides.
+    grant_msat = peer_cap_msat * grant_weight / 100.0
+    in_adj_ppm = adjusted_net_ppm(in_net, in_fwd, grant_msat, grant, gain)
 
     out_fwd = peer.get("out_forwarded", 0)
     out_earn = peer.get("out_earnings", 0)
     out_exp = peer.get("out_expenditures", 0)
     out_net = out_earn - out_exp
     out_net_ppm = safe_ppm(out_net, out_fwd)
-    out_move = peer_cap_msat * fill_loc / 100.0
-    out_adj_ppm = adjusted_net_ppm(out_net, out_fwd, out_move, grant, gain)
+    out_adj_ppm = adjusted_net_ppm(out_net, out_fwd, grant_msat, grant,
+                                    gain)
 
     cap_sat = cap_msat // 1000
     local_sat = to_us_msat // 1000
@@ -497,12 +497,17 @@ def main():
     parser.add_argument(
         "--grant", type=float, default=None, metavar="PPM",
         help="Assumed prior earnings rate (ppm) credited to every peer on "
-             "both sides, as if it had already earned that rate on one "
-             "rebalance's worth of volume, w = cap * fill-loc / 100 on the "
-             "out side and cap * (100 - drain-loc) / 100 on the in side: "
+             "both sides, as if it had already earned that rate on "
+             "--grant-weight percent of its capacity, w: "
              "(net + w*grant/1e6) / (fwd + w).  Peers with no record read "
              "exactly PPM.  Default: live clboss-xrebalance-grant, else 0 "
              "(record-only)."
+    )
+    parser.add_argument(
+        "--grant-weight", type=float, default=None, metavar="PCT",
+        help="Volume the grant is assumed earned on, as a percent of the "
+             "peer's capacity, both sides.  Default: live "
+             "clboss-xrebalance-grant-weight, else 25."
     )
     parser.add_argument(
         "--gain", type=float, default=None, metavar="MULT",
@@ -621,6 +626,14 @@ def main():
     else:
         args.grant = 0.0
         settings.append(("grant", "0", "default"))
+    if args.grant_weight is not None:
+        settings.append(("grant-weight", f"{args.grant_weight:g}", "arg"))
+    elif _num(live.get("grant_weight")) is not None:
+        args.grant_weight = _num(live["grant_weight"])
+        settings.append(("grant-weight", f"{args.grant_weight:g}", "live"))
+    else:
+        args.grant_weight = 25.0
+        settings.append(("grant-weight", "25", "default"))
     if args.gain is not None:
         settings.append(("gain", f"{args.gain:g}", "arg"))
     elif _num(live.get("gain")) is not None:
@@ -631,6 +644,8 @@ def main():
         settings.append(("gain", "1", "default"))
     if args.grant < 0.0:
         sys.exit("--grant must be >= 0")
+    if args.grant_weight <= 0.0:
+        sys.exit("--grant-weight must be > 0")
     if not (args.gain > 0.0):
         sys.exit("--gain must be > 0")
 
@@ -730,9 +745,8 @@ def main():
             lightning_dir, network_option, peer_id, peer_metrics
         )
 
-    # grant's credit base: one rebalance's worth, per side, of the peer's
-    # total capacity across its channels, matching the driver's per-node
-    # join.
+    # grant's credit base: grant-weight percent of the peer's total
+    # capacity across its channels, matching the driver's per-node join.
     peer_cap_msat = {}
     for ch in channels.values():
         peer_cap_msat[ch["peer_id"]] = (
@@ -745,8 +759,7 @@ def main():
         peer = peers[ch["peer_id"]]
         rows.append(compute_row(ch, peer, args.days,
                                 peer_cap_msat[ch["peer_id"]],
-                                args.fill_loc, args.drain_loc,
-                                args.grant, args.gain))
+                                args.grant_weight, args.grant, args.gain))
     # A balance-unmanaged peer reads 'U' in the On column and, like an
     # offline one, never joins a pool; it keeps its band tint.
     for r in rows:
@@ -1228,9 +1241,8 @@ def main():
     print("# InNetPpm/OutNetPpm = (earnings - expenses) * 1e6 / forwarded "
           "msat on that side")
     print("# InAdjPpm/OutAdjPpm = the same with grant and gain applied, "
-          "(net + w*grant/1e6) / (fwd + w) * gain with w = cap * (100 - "
-          "drain-loc) / 100 (in) or cap * fill-loc / 100 (out); what the "
-          "driver ranks by")
+          "(net + w*grant/1e6) / (fwd + w) * gain with w = cap * "
+          "grant-weight / 100; what the driver ranks by")
     print(f"# Loc% = current local balance / capacity")
     print("# On: . = connected, X = offline, U = balance-unmanaged "
           "(clboss-unmanage); only . rows can join a pool")

--- a/contrib/clboss-xrebalance-view
+++ b/contrib/clboss-xrebalance-view
@@ -181,12 +181,14 @@ def safe_ppm(numerator_msat, denominator_msat):
     return (numerator_msat * 1_000_000) / denominator_msat
 
 
-def adjusted_net_ppm(net_msat, fwd_msat, peer_cap_msat, grant, gain):
+def adjusted_net_ppm(net_msat, fwd_msat, move_msat, grant, gain):
     """The AdjPpm the driver joins for one side: strict (net / fwd) when
     grant is 0, else the peer credited an assumed prior of grant ppm on
-    one capacity-turn -- (net + cap*grant/1e6) / (fwd + cap) -- and gain
-    scales the result either way.  Mirrors XRebalancer's joined()."""
-    g_vol = peer_cap_msat if grant > 0 else 0
+    move_msat, that side's rebalance volume (cap * fill-loc / 100 on
+    the out side, cap * (100 - drain-loc) / 100 on the in side) --
+    (net + w*grant/1e6) / (fwd + w) -- and gain scales the result either
+    way.  Mirrors XRebalancer's joined()."""
+    g_vol = move_msat if grant > 0 else 0
     denom = fwd_msat + g_vol
     if denom <= 0:
         return None
@@ -353,7 +355,8 @@ def pad_string(s, width):
     return s + " " * (width - wcswidth(s))
 
 
-def compute_row(channel, peer, window_days, peer_cap_msat, grant, gain):
+def compute_row(channel, peer, window_days, peer_cap_msat, fill_loc,
+                drain_loc, grant, gain):
     cap_msat = channel.get("total_msat", 0) or 0
     to_us_msat = channel.get("to_us_msat", 0) or 0
     pct_local = (100.0 * to_us_msat / cap_msat) if cap_msat > 0 else 0.0
@@ -372,16 +375,18 @@ def compute_row(channel, peer, window_days, peer_cap_msat, grant, gain):
     in_exp = peer.get("in_expenditures", 0)
     in_net = in_earn - in_exp
     in_net_ppm = safe_ppm(in_net, in_fwd)
-    in_adj_ppm = adjusted_net_ppm(in_net, in_fwd, peer_cap_msat,
-                                   grant, gain)
+    # grant's notional volume per side: one drain (in) or one fill (out)
+    # of the peer's capacity, to the band edge.
+    in_move = peer_cap_msat * (100.0 - drain_loc) / 100.0
+    in_adj_ppm = adjusted_net_ppm(in_net, in_fwd, in_move, grant, gain)
 
     out_fwd = peer.get("out_forwarded", 0)
     out_earn = peer.get("out_earnings", 0)
     out_exp = peer.get("out_expenditures", 0)
     out_net = out_earn - out_exp
     out_net_ppm = safe_ppm(out_net, out_fwd)
-    out_adj_ppm = adjusted_net_ppm(out_net, out_fwd, peer_cap_msat,
-                                    grant, gain)
+    out_move = peer_cap_msat * fill_loc / 100.0
+    out_adj_ppm = adjusted_net_ppm(out_net, out_fwd, out_move, grant, gain)
 
     cap_sat = cap_msat // 1000
     local_sat = to_us_msat // 1000
@@ -493,9 +498,11 @@ def main():
         "--grant", type=float, default=None, metavar="PPM",
         help="Assumed prior earnings rate (ppm) credited to every peer on "
              "both sides, as if it had already earned that rate on one "
-             "capacity-turn of volume: (net + cap*grant/1e6) / (fwd + cap).  "
-             "Peers with no record read exactly PPM.  Default: live "
-             "clboss-xrebalance-grant, else 0 (record-only)."
+             "rebalance's worth of volume, w = cap * fill-loc / 100 on the "
+             "out side and cap * (100 - drain-loc) / 100 on the in side: "
+             "(net + w*grant/1e6) / (fwd + w).  Peers with no record read "
+             "exactly PPM.  Default: live clboss-xrebalance-grant, else 0 "
+             "(record-only)."
     )
     parser.add_argument(
         "--gain", type=float, default=None, metavar="MULT",
@@ -723,8 +730,9 @@ def main():
             lightning_dir, network_option, peer_id, peer_metrics
         )
 
-    # grant's credit base: the peer's total capacity across its channels,
-    # matching the driver's per-node join.
+    # grant's credit base: one rebalance's worth, per side, of the peer's
+    # total capacity across its channels, matching the driver's per-node
+    # join.
     peer_cap_msat = {}
     for ch in channels.values():
         peer_cap_msat[ch["peer_id"]] = (
@@ -737,6 +745,7 @@ def main():
         peer = peers[ch["peer_id"]]
         rows.append(compute_row(ch, peer, args.days,
                                 peer_cap_msat[ch["peer_id"]],
+                                args.fill_loc, args.drain_loc,
                                 args.grant, args.gain))
     # A balance-unmanaged peer reads 'U' in the On column and, like an
     # offline one, never joins a pool; it keeps its band tint.
@@ -1219,8 +1228,9 @@ def main():
     print("# InNetPpm/OutNetPpm = (earnings - expenses) * 1e6 / forwarded "
           "msat on that side")
     print("# InAdjPpm/OutAdjPpm = the same with grant and gain applied, "
-          "(net + cap*grant/1e6) / (fwd + cap) * gain; what the driver "
-          "ranks by")
+          "(net + w*grant/1e6) / (fwd + w) * gain with w = cap * (100 - "
+          "drain-loc) / 100 (in) or cap * fill-loc / 100 (out); what the "
+          "driver ranks by")
     print(f"# Loc% = current local balance / capacity")
     print("# On: . = connected, X = offline, U = balance-unmanaged "
           "(clboss-unmanage); only . rows can join a pool")

--- a/docs/xrebalance_overview.md
+++ b/docs/xrebalance_overview.md
@@ -160,14 +160,19 @@ or `off`.  What each knob moves:
 earned what a transfer costs.
 
 - `grant` credits every peer, on both sides, an assumed rate of
-  `grant` ppm as if it had already been earned on one capacity-turn
-  of volume:
+  `grant` ppm as if it had already been earned on one rebalance's
+  worth of volume: on the out side `fill-loc` percent of the peer's
+  capacity, one fill; on the in side `100 - drain-loc` percent, one
+  drain:
 
-      adjusted rate = (net + capacity * grant / 1e6) / (forwarded + capacity)
+      w = capacity * fill-loc / 100            (out side)
+      w = capacity * (100 - drain-loc) / 100   (in side)
+      adjusted rate = (net + w * grant / 1e6) / (forwarded + w)
 
-  A peer with no record reads exactly `grant`.  The credit weighs
-  one capacity-turn of volume, so it matters only while a peer's
-  forwarded volume is small next to its capacity; as the record
+  A peer with no record reads exactly `grant`, and the credit is
+  what one move to the band edge costs at `grant` ppm.  The credit
+  weighs one rebalance's worth of volume, so it matters only while
+  a peer's forwarded volume is small next to that; as the record
   grows, the adjusted rate converges on the measured net rate, and
   expenditures spend the credit down.  It admits new peers and
   peers with thin records, and lifts a slightly negative record to
@@ -186,9 +191,9 @@ raw and `InAdjPpm` / `OutAdjPpm` adjusted, so the effect of the two
 settings is visible per peer.  A node with no record cannot
 rebalance under the strict rule at all, since no side has earned
 anything; `grant` is what admits it, and the credit dilutes on its
-own as forwarded volume grows past the channel capacity.  One
-production node runs `grant` 100 and `gain` 1.2 on a mature
-record.
+own as forwarded volume grows past one rebalance's worth of the
+channel.  One production node runs `grant` 100 and `gain` 1.2 on a
+mature record.
 
 What to watch:
 

--- a/docs/xrebalance_overview.md
+++ b/docs/xrebalance_overview.md
@@ -154,25 +154,23 @@ or `off`.  What each knob moves:
 | `route-cost-floor` | auto | how wide a matched set may grow: a fixed ppm floor on the fee ceiling, or `auto`, a ladder of floors derived from the node's own rates with a random rung picked each cycle, so focused cycles at high ceilings and wide cycles at low ones alternate |
 | `maxparts` | 80 | how finely a transfer may split; larger means more paths and more refusals per solve |
 | `grant` | 0 | an assumed prior rate credited to every peer, see below |
+| `grant-weight` | 25 | the volume the grant is assumed earned on, percent of capacity, see below |
 | `gain` | 1 | a multiplier on the measured rates, see below |
 
 **grant and gain** bend the strict rule that a side must have
 earned what a transfer costs.
 
 - `grant` credits every peer, on both sides, an assumed rate of
-  `grant` ppm as if it had already been earned on one rebalance's
-  worth of volume: on the out side `fill-loc` percent of the peer's
-  capacity, one fill; on the in side `100 - drain-loc` percent, one
-  drain:
+  `grant` ppm as if it had already been earned on `grant-weight`
+  percent of the peer's capacity:
 
-      w = capacity * fill-loc / 100            (out side)
-      w = capacity * (100 - drain-loc) / 100   (in side)
+      w = capacity * grant-weight / 100
       adjusted rate = (net + w * grant / 1e6) / (forwarded + w)
 
-  A peer with no record reads exactly `grant`, and the credit is
-  what one move to the band edge costs at `grant` ppm.  The credit
-  weighs one rebalance's worth of volume, so it matters only while
-  a peer's forwarded volume is small next to that; as the record
+  A peer with no record reads exactly `grant`.  `grant-weight` sets
+  how much record it takes to outweigh the credit: the credit
+  matters only while a peer's forwarded volume is small next to
+  that share of its capacity; as the record
   grows, the adjusted rate converges on the measured net rate, and
   expenditures spend the credit down.  It admits new peers and
   peers with thin records, and lifts a slightly negative record to
@@ -191,7 +189,7 @@ raw and `InAdjPpm` / `OutAdjPpm` adjusted, so the effect of the two
 settings is visible per peer.  A node with no record cannot
 rebalance under the strict rule at all, since no side has earned
 anything; `grant` is what admits it, and the credit dilutes on its
-own as forwarded volume grows past one rebalance's worth of the
+own as forwarded volume grows past `grant-weight` percent of the
 channel.  One production node runs `grant` 100 and `gain` 1.2 on a
 mature record.
 

--- a/tests/boss/test_xrebalancer_grant.cpp
+++ b/tests/boss/test_xrebalancer_grant.cpp
@@ -1,0 +1,288 @@
+#undef NDEBUG
+
+#include"Boss/Mod/RebalanceUnmanager.hpp"
+#include"Boss/Mod/Rpc.hpp"
+#include"Boss/Mod/Waiter.hpp"
+#include"Boss/Mod/XRebalancer.hpp"
+#include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/DemandObserved.hpp"
+#include"Boss/Msg/Init.hpp"
+#include"Boss/Msg/JsonCout.hpp"
+#include"Boss/Msg/Option.hpp"
+#include"Boss/Msg/RequestRebalanceMode.hpp"
+#include"Boss/Msg/RequestRpcCommand.hpp"
+#include"Boss/Msg/ResponseRebalanceMode.hpp"
+#include"Boss/Msg/ResponseRpcCommand.hpp"
+#include"Boss/RebalanceMode.hpp"
+#include"Boss/Shutdown.hpp"
+#include"Ev/Io.hpp"
+#include"Ev/now.hpp"
+#include"Ev/start.hpp"
+#include"Ev/yield.hpp"
+#include"Jsmn/Object.hpp"
+#include"Json/Out.hpp"
+#include"Ln/NodeId.hpp"
+#include"Ln/Scid.hpp"
+#include"Net/Connector.hpp"
+#include"Net/Fd.hpp"
+#include"Net/SocketFd.hpp"
+#include"S/Bus.hpp"
+#include"Secp256k1/PubKey.hpp"
+#include"Secp256k1/Signature.hpp"
+#include"Secp256k1/SignerIF.hpp"
+#include"Sha256/Hash.hpp"
+#include"Sqlite3.hpp"
+#include<assert.h>
+#include<ctime>
+#include<iostream>
+#include<sstream>
+#include<string>
+#include<sys/socket.h>
+
+/* Checks the weight of clboss-xrebalance-grant: the credit is one
+ * rebalance's worth of volume per side -- fill-loc percent of the
+ * peer's capacity on the out side, 100 - drain-loc percent on the
+ * in side -- not a whole capacity-turn.  Both peers have a
+ * 1_000_000_000 msat channel and 1_000_000_000 msat forwarded on
+ * their candidate side.  With grant 100, the default fill-loc 25,
+ * and drain-loc 70: A's out side weighs 250_000_000 msat,
+ * (1_000_000 + 25_000) / 1.25e9 = 820 ppm; B's in side weighs
+ * 300_000_000 msat, (500_000 + 30_000) / 1.3e9 = 407.7 ppm; the
+ * demand cycle prices at 1228 ppm.  A whole capacity-turn would
+ * give 550 + 300 = 850; fill-loc on both sides, 820 + 420 = 1240.  */
+
+namespace {
+
+/* Peer A: 5% local -> fill candidate; the demand target.  */
+auto const node_a = "020000000000000000000000000000000000000000000000000000000000000000";
+/* Peer B: 95% local -> the only drain candidate.  */
+auto const node_b = "020000000000000000000000000000000000000000000000000000000000000001";
+
+auto const scid_a = "103x1x0";
+auto const scid_b = "103x1x1";
+
+auto const listpeerchannels_result = R"JSON(
+{
+  "channels": [
+    {
+      "state": "CHANNELD_NORMAL",
+      "to_us_msat": "50000000msat",
+      "total_msat": "1000000000msat",
+      "short_channel_id": "103x1x0",
+      "peer_id": "020000000000000000000000000000000000000000000000000000000000000000",
+      "peer_connected": true
+    },
+    {
+      "state": "CHANNELD_NORMAL",
+      "to_us_msat": "950000000msat",
+      "total_msat": "1000000000msat",
+      "short_channel_id": "103x1x1",
+      "peer_id": "020000000000000000000000000000000000000000000000000000000000000001",
+      "peer_connected": true
+    }
+  ]
+}
+)JSON";
+
+class DummyConnector : public Net::Connector {
+public:
+	Net::SocketFd
+	connect(std::string const& host, int port) override {
+		(void) host;
+		(void) port;
+		return Net::SocketFd();
+	}
+};
+
+class DummySigner : public Secp256k1::SignerIF {
+public:
+	Secp256k1::PubKey
+	get_pubkey_tweak(Secp256k1::PrivKey const& tweak) override {
+		(void) tweak;
+		return Secp256k1::PubKey();
+	}
+
+	Secp256k1::Signature
+	get_signature_tweak( Secp256k1::PrivKey const& tweak
+			   , Sha256::Hash const& m
+			   ) override {
+		(void) tweak;
+		(void) m;
+		return Secp256k1::Signature();
+	}
+
+	Sha256::Hash
+	get_privkey_salted_hash(std::uint8_t salt[32]) override {
+		if (!salt)
+			return Sha256::Hash();
+		auto hash = Sha256::Hash();
+		hash.from_buffer(salt);
+		return hash;
+	}
+};
+
+bool has_scid(Jsmn::Object const& arr, char const* scid) {
+	for (auto i = std::size_t(0); i < arr.size(); ++i)
+		if (std::string(arr[i]["scid"]) == scid)
+			return true;
+	return false;
+}
+
+Ev::Io<void> wait_flag(bool& flag, double start) {
+	return Ev::yield().then([&flag, start]() {
+		if (flag)
+			return Ev::lift();
+		assert(Ev::now() - start < 10.0); /* Time out.  */
+		return wait_flag(flag, start);
+	});
+}
+
+Ev::Io<void> set_option(S::Bus& bus, char const* name, char const* json) {
+	return bus.raise(Boss::Msg::Option{
+		name, Jsmn::Object::parse_json(json), nullptr
+	});
+}
+
+}
+
+int main() {
+	auto bus = S::Bus();
+	Boss::Mod::Waiter waiter(bus);
+
+	bus.subscribe<Boss::Msg::RequestRebalanceMode
+		     >([&](Boss::Msg::RequestRebalanceMode const& m) {
+		return bus.raise(Boss::Msg::ResponseRebalanceMode{
+			m.requester, Boss::RebalanceMode::xrebalance
+		});
+	});
+
+	auto log_lines = std::string();
+	bus.subscribe<Boss::Msg::JsonCout
+		     >([&](Boss::Msg::JsonCout const& m) {
+		log_lines += m.obj.output();
+		log_lines += "\n";
+		return Ev::lift();
+	});
+
+	auto xreb_called = false;
+	auto xreb_params = std::string();
+	bus.subscribe<Boss::Msg::RequestRpcCommand
+		     >([&](Boss::Msg::RequestRpcCommand const& m) {
+		auto respond = [&](char const* res) {
+			return bus.raise(Boss::Msg::ResponseRpcCommand{
+				m.requester, true,
+				Jsmn::Object::parse_json(res), ""
+			});
+		};
+		if (m.command == "listpeerchannels")
+			return respond(listpeerchannels_result);
+		if (m.command == "xrebalance") {
+			xreb_params = m.params.output();
+			xreb_called = true;
+			return respond(R"JSON({})JSON");
+		}
+		std::cerr << "UNMOCKED COMMAND " << m.command << std::endl;
+		assert(0);
+		return Ev::lift();
+	});
+
+	Boss::Mod::RebalanceUnmanager unmanager(bus, {});
+
+	auto mut = Boss::Mod::XRebalancer(bus, waiter);
+
+	auto connector = DummyConnector();
+	auto signer = DummySigner();
+	auto db = Sqlite3::Db(":memory:");
+	int sockets[2];
+	auto sockres = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+	assert(sockres >= 0);
+	auto server_socket = Net::Fd(sockets[0]);
+	auto client_socket = Net::Fd(sockets[1]);
+	auto rpc = Boss::Mod::Rpc(bus, std::move(client_socket));
+
+	auto code = Ev::lift().then([&]() {
+		return db.transact();
+	}).then([&](Sqlite3::Tx tx) {
+		tx.query_execute(R"QRY(
+		CREATE TABLE "EarningsTracker"
+		     ( node TEXT NOT NULL
+		     , time_bucket REAL NOT NULL
+		     , in_earnings INTEGER NOT NULL
+		     , in_forwarded INTEGER NOT NULL
+		     , in_expenditures INTEGER NOT NULL
+		     , out_earnings INTEGER NOT NULL
+		     , out_forwarded INTEGER NOT NULL
+		     , out_expenditures INTEGER NOT NULL
+		     );
+		)QRY");
+		auto now = double(std::time(nullptr));
+		auto insert = [&]( char const* node
+				 , std::int64_t in_e, std::int64_t in_f
+				 , std::int64_t out_e, std::int64_t out_f
+				 ) {
+			tx.query(R"QRY(
+			INSERT INTO "EarningsTracker"
+			VALUES( :node, :time_bucket
+			      , :in_e, :in_f, 0
+			      , :out_e, :out_f, 0
+			      );
+			)QRY")
+				.bind(":node", node)
+				.bind(":time_bucket", now)
+				.bind(":in_e", in_e)
+				.bind(":in_f", in_f)
+				.bind(":out_e", out_e)
+				.bind(":out_f", out_f)
+				.execute();
+		};
+		insert(node_a, 0, 0, 1000000, 1000000000); /* out 1000ppm */
+		insert(node_b, 500000, 1000000000, 0, 0);  /* in 500ppm */
+		tx.commit();
+
+		/* Pause the Poisson loop so only the demand trigger
+		 * below can start a cycle.  */
+		return set_option(bus, "clboss-xrebalance-per-hour",
+				  R"JSON("0")JSON");
+	}).then([&]() {
+		return set_option(bus, "clboss-xrebalance-grant",
+				  R"JSON("100")JSON");
+	}).then([&]() {
+		return set_option(bus, "clboss-xrebalance-drain-loc",
+				  R"JSON("70")JSON");
+	}).then([&]() {
+		return bus.raise(Boss::Msg::DbResource{db});
+	}).then([&]() {
+		return bus.raise(Boss::Msg::Init{
+			Boss::Msg::Network_Regtest,
+			rpc,
+			Ln::NodeId(node_a),
+			db,
+			connector,
+			signer,
+			std::string(),
+			false
+		});
+	}).then([&]() {
+		return bus.raise(Boss::Msg::DemandObserved{
+			Ln::Scid(std::string(scid_a))
+		});
+	}).then([&]() {
+		return wait_flag(xreb_called, Ev::now());
+	}).then([&]() {
+		auto req = Jsmn::Object::parse_json(xreb_params.c_str());
+		assert(has_scid(req["destinations"], scid_a));
+		assert(has_scid(req["sources"], scid_b));
+
+		/* The fee ceiling is the sum of the two side-weighted
+		 * adjusted rates.  */
+		assert(log_lines.find(
+			"maxfee=1228 ppm (target 820.0 + min offered 407.7)")
+			!= std::string::npos);
+
+		return bus.raise(Boss::Shutdown{});
+	}).then([&]() {
+		return Ev::lift(0);
+	});
+
+	return Ev::start(code);
+}

--- a/tests/boss/test_xrebalancer_grant.cpp
+++ b/tests/boss/test_xrebalancer_grant.cpp
@@ -39,17 +39,15 @@
 #include<string>
 #include<sys/socket.h>
 
-/* Checks the weight of clboss-xrebalance-grant: the credit is one
- * rebalance's worth of volume per side -- fill-loc percent of the
- * peer's capacity on the out side, 100 - drain-loc percent on the
- * in side -- not a whole capacity-turn.  Both peers have a
- * 1_000_000_000 msat channel and 1_000_000_000 msat forwarded on
- * their candidate side.  With grant 100, the default fill-loc 25,
- * and drain-loc 70: A's out side weighs 250_000_000 msat,
- * (1_000_000 + 25_000) / 1.25e9 = 820 ppm; B's in side weighs
- * 300_000_000 msat, (500_000 + 30_000) / 1.3e9 = 407.7 ppm; the
- * demand cycle prices at 1228 ppm.  A whole capacity-turn would
- * give 550 + 300 = 850; fill-loc on both sides, 820 + 420 = 1240.  */
+/* Checks the weight of clboss-xrebalance-grant: the credit is
+ * assumed earned on clboss-xrebalance-grant-weight percent of the
+ * peer's capacity, both sides.  Both peers have a 1_000_000_000
+ * msat channel and 1_000_000_000 msat forwarded on their candidate
+ * side.  With grant 100 and grant-weight 30 the prior weighs
+ * 300_000_000 msat: A out, (1_000_000 + 30_000) / 1.3e9 = 792.3
+ * ppm; B in, (500_000 + 30_000) / 1.3e9 = 407.7 ppm; the demand
+ * cycle prices at 1200 ppm.  The default weight 25 would give
+ * 820 + 420 = 1240; a whole capacity-turn, 550 + 300 = 850.  */
 
 namespace {
 
@@ -247,8 +245,8 @@ int main() {
 		return set_option(bus, "clboss-xrebalance-grant",
 				  R"JSON("100")JSON");
 	}).then([&]() {
-		return set_option(bus, "clboss-xrebalance-drain-loc",
-				  R"JSON("70")JSON");
+		return set_option(bus, "clboss-xrebalance-grant-weight",
+				  R"JSON("30")JSON");
 	}).then([&]() {
 		return bus.raise(Boss::Msg::DbResource{db});
 	}).then([&]() {
@@ -273,10 +271,9 @@ int main() {
 		assert(has_scid(req["destinations"], scid_a));
 		assert(has_scid(req["sources"], scid_b));
 
-		/* The fee ceiling is the sum of the two side-weighted
-		 * adjusted rates.  */
+		/* The fee ceiling is the sum of the two adjusted rates.  */
 		assert(log_lines.find(
-			"maxfee=1228 ppm (target 820.0 + min offered 407.7)")
+			"maxfee=1200 ppm (target 792.3 + min offered 407.7)")
 			!= std::string::npos);
 
 		return bus.raise(Boss::Shutdown{});


### PR DESCRIPTION
For 0.17.1.  0.17.0 ships from rc3 with the grant weighing a whole
capacity-turn for as long as the peer has a channel; this changes
the formula, so it waits for the point release.

clboss-xrebalance-grant credits every peer an assumed rate as if
already earned on some volume.  Two changes to that volume:

1. It is a setting.  It was one whole capacity-turn, a prior
heavier than a new channel needs, and it pulls down peers with
real records: on a node running grant 100 / gain 1.2, a side
earning 458 ppm on 3.8 turns of its capacity read 383 before
gain, the prior still weighing one part in 4.8.  The volume is
now a dynamic option, clboss-xrebalance-grant-weight, a percent
of the peer's capacity applied on both sides, default 25.

2. It fades.  A fixed volume thins the credit as the record grows
but never ends it, so a break-even channel with a large record
kept a positive adjusted rate from the credit alone: on the same
node a 5M channel was filled repeatedly at 115-138 ppm and
forwarded the funds out within minutes at 44 ppm, its own record
saying 10 ppm net and the credit lifting it to 60.  Real forwarded
volume now replaces the credit one for one:

    w = capacity * grant-weight / 100        (msat; grant-weight is a percent)
    g = max(0, w - forwarded)
    adjusted = (net + g * grant / 1e6) / (forwarded + g) * gain

A side with no record still reads exactly grant, and expenditures
still spend the credit down.  At half of w forwarded the result is
half grant and half the measured rate; from w on the credit is
gone and the side reads its own record alone.  The weight says how
much record, as a percent of capacity, ends the grant.  It is not
tied to the fill/drain bands: the band edge says where a move
stops, the weight how much evidence replaces the guess.

contrib/clboss-xrebalance-view takes --grant-weight and shows the
same AdjPpm; the cycle line notes "grant N over P%"; the option
help, the README entry, docs/xrebalance_overview.md and the
CHANGELOG follow.  tests/boss/test_xrebalancer_grant prices a fill
target at half the weight from a source past it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add configurable XRebalancer grant weighting with a 25% default of aggregate peer capacity. Forwarded volume reduces grant credit one-for-one.
- Update the view tool with `--grant-weight`, validation, and matching adjusted-rate calculations.
- Update tests, documentation, changelog, and build integration for the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->