### PR TITLE
AmountSettingsHandler: floor --clboss-min-onchain at CLN's min-emergency floor (30000 sat)

### DIFF
--- a/Boss/Mod/AmountSettingsHandler.cpp
+++ b/Boss/Mod/AmountSettingsHandler.cpp
@@ -40,6 +40,15 @@ auto const additional_remaining = Ln::Amount::sat(20000);
 auto const min_usable_max_channel =
 	(1.0 + trigger_factor) * min_min_channel + additional_remaining;
 
+/* CLBOSS computes the channel-creation budget as
+ *   onchain_spendable - reserve
+ * and spends down to that level, but CLN refuses any funding
+ * transaction that would leave less than its `min-emergency-msat`
+ * (25,000 sat default) plus the funding fee.  A reserve below
+ * that floor makes every multifundchannel fail with error 313
+ * forever while churning the candidate table, so floor it.  */
+auto const min_usable_reserve = Ln::Amount::sat(30000);
+
 Ln::Amount parse_sats(Jsmn::Object value) {
 	auto is = std::istringstream(std::string(value));
 	auto sats = std::uint64_t();
@@ -173,6 +182,23 @@ private:
 						  min_usable_max_channel.to_sat()
 						);
 				settings->max_channel = min_usable_max_channel;
+			}
+			if (settings->reserve < min_usable_reserve) {
+				act += Boss::log( bus, Warn
+						, "AmountSettingsHandler: "
+						  "--clboss-min-onchain %u "
+						  "below the CLN "
+						  "min-emergency-msat floor "
+						  "(25000 sat default) plus "
+						  "funding fees; every channel "
+						  "creation would fail with "
+						  "error 313.  Forced to %u."
+						, (unsigned int)
+						  settings->reserve.to_sat()
+						, (unsigned int)
+						  min_usable_reserve.to_sat()
+						);
+				settings->reserve = min_usable_reserve;
 			}
 
 			/* Compute the rest.  */

--- a/tests/boss/test_amountsettingshandler.cpp
+++ b/tests/boss/test_amountsettingshandler.cpp
@@ -23,25 +23,36 @@ struct Case {
 	/* Option values as delivered by lightningd; nullptr = unset.  */
 	char const* min_channel;
 	char const* max_channel;
+	char const* min_onchain;
 	/* Expected settings after validation.  */
 	std::uint64_t expect_min;
 	std::uint64_t expect_max;
+	std::uint64_t expect_reserve;
 };
 
 auto const cases = std::vector<Case>{
 	/* Defaults pass through untouched.  */
-	{ nullptr , nullptr  ,  500000, 16777215},
+	{ nullptr , nullptr  , nullptr   ,  500000, 16777215,   30000},
 	/* A pair satisfying max >= 3 * min + 20k passes through.  */
-	{"1000000", "3020000", 1000000,  3020000},
+	{"1000000", "3020000", nullptr  , 1000000,  3020000,   30000},
 	/* min below the absolute floor is raised.  */
-	{ "400000", nullptr  ,  500000, 16777215},
+	{ "400000", nullptr  , nullptr  ,  500000, 16777215,   30000},
 	/* Conflicting pair: max kept, min lowered to the largest
 	 * value satisfying min_channel + min_remaining <= max_channel.  */
-	{"1000000", "2000000",  660000,  2000000},
+	{"1000000", "2000000", nullptr  ,  660000,  2000000,   30000},
 	/* Non-divisible conflict: truncation keeps the invariant.  */
-	{"1000000", "3000000",  993333,  3000000},
+	{"1000000", "3000000", nullptr  ,  993333,  3000000,   30000},
 	/* max too low for any allowed min: max raised, min floored.  */
-	{"2000000", "1000000",  500000,  1520000},
+	{"2000000", "1000000", nullptr  ,  500000, 1520000,   30000},
+	/* F-3: reserve below CLN min-emergency-msat (25000 sat
+	 * default) + funding fees makes every multifundchannel
+	 * fail 313 forever; forced up to the usable floor.  */
+	{ nullptr , nullptr  ,  "10000" ,  500000, 16777215,   30000},
+	{ nullptr , nullptr  ,  "29999" ,  500000, 16777215,   30000},
+	/* Exactly at the floor stays.  */
+	{ nullptr , nullptr  ,  "30000" ,  500000, 16777215,   30000},
+	/* Higher reserves pass through untouched.  */
+	{ nullptr , nullptr  ,  "500000",  500000, 16777215,  500000},
 };
 
 Boss::Msg::Option make_option(char const* name, char const* value) {
@@ -90,6 +101,12 @@ int main() {
 			return bus.raise(make_option( "clboss-max-channel"
 						    , c.max_channel
 						    ));
+		}).then([&bus, c]() {
+			if (!c.min_onchain)
+				return Ev::lift();
+			return bus.raise(make_option( "clboss-min-onchain"
+						    , c.min_onchain
+						    ));
 		}).then([&bus]() {
 			return bus.raise(Boss::Msg::EndOfOptions{});
 		}).then([captured, have, c]() {
@@ -99,6 +116,9 @@ int main() {
 			      );
 			assert( captured->max_channel
 			     == Ln::Amount::sat(c.expect_max)
+			      );
+			assert( captured->reserve
+			     == Ln::Amount::sat(c.expect_reserve)
 			      );
 			/* min_remaining derivation.  */
 			assert( captured->min_remaining


### PR DESCRIPTION
## Problem

`--clboss-min-onchain` is accepted at any value ≥ 0.  CLN itself
refuses to let the wallet spend below `min-emergency-msat`
(25 000 sat by default) plus funding fees — so any CLBOSS reserve
below that floor produces a **permanent channel-creation failure
loop**: CLBOSS computes `worth = onchain − reserve`, plans
channel(s) spending the wallet down past CLN's floor, the carpenter's
`multifundchannel` fails with error 313 ("We would not have enough
left for min-emergency-msat 25000sat"), the attempted candidates are
removed from the candidate table, the next cycle re-proposes them —
forever.  Observed live on regtest: a node with
`--clboss-min-onchain=10000` loops 313 with zero channels ever
created; the same node with the floor applied lands both planned
channels.

The trap is wealth-level-dependent (an over-funded wallet never
spends down to the reserve, which hides it in testing) and
silent (nothing validates the config at startup).

## Fix

`AmountSettingsHandler` End-of-options validation now coerces the
reserve below `min_usable_reserve = 30000` sat (= CLN's 25 000 sat
default floor + funding-fee headroom) to that floor, with a `Warn`
naming the mechanism.  The floor equals the existing default, so
default configurations are no-ops.

## Tests

Table-driven cases `10000 → 30000` and `29999 → 30000` added to
`tests/boss/test_amountsettingshandler.cpp` (plus the existing
default no-op cases).  `make check` green.

Live validation (regtest A/B, identical flags, funded
back-to-back, deciders firing on the same block with the same fee
verdict): unpatched loops `multifundchannel` 313 with 0 channels;
patched logs the Warn and lands both channels CHANNELD_NORMAL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Enforce a minimum `--clboss-min-onchain` reserve of 30,000 sat during end-of-options validation.
- Log a warning when a value below the minimum is raised to 30,000 sat. Keep the existing default unchanged.
- Add table-driven tests for reserves below, at, and above the minimum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->