### PR TITLE
ChannelCandidatePreinvestigator: queue concurrent same-node preinvestigation Cases

### DIFF
--- a/Boss/Mod/ChannelCandidatePreinvestigator.cpp
+++ b/Boss/Mod/ChannelCandidatePreinvestigator.cpp
@@ -127,11 +127,16 @@ private:
 		}
 	};
 
-	std::map<std::string, std::shared_ptr<Case>> cases;
+	/* Several finders can concurrently preinvestigate batches
+	 * that share a proposal node (e.g. multiple patrons of the
+	 * same popular hub); queue the concurrent Cases per node
+	 * instead of overwriting, so every Case survives to receive
+	 * its own ResponseConnect (clboss#11).  */
+	std::map<std::string, std::queue<std::shared_ptr<Case>>> cases;
 	void add_case( std::string const& node
 		     , std::shared_ptr<Case> c
 		     ) {
-		cases[node] = std::move(c);
+		cases[node].push(std::move(c));
 	}
 
 	Ev::Io<void> on_preinv(Msg::PreinvestigateChannelCandidates const& p) {
@@ -144,9 +149,18 @@ private:
 		if (it == cases.end())
 			return Ev::lift();
 
-		/* Remove it from cases.  */
-		auto c = std::move(it->second);
-		cases.erase(it);
+		auto& queued = it->second;
+		if (queued.empty())
+			return Ev::lift();
+
+		/* Remove it from cases, erasing the entry before
+		 * executing so that a Case re-registering the same
+		 * node from within the execution lands in a fresh
+		 * entry.  */
+		auto c = std::move(queued.front());
+		queued.pop();
+		if (queued.empty())
+			cases.erase(it);
 
 		/* Execute it.  */
 		return c->on_connect_response(r.success).then([c]() {

--- a/Makefile.am
+++ b/Makefile.am
@@ -615,6 +615,7 @@ TESTS = \
 	tests/boss/test_askrene_layer \
 	tests/boss/test_availablerpccommandsannouncer \
 	tests/boss/test_channel_create_destroy_monitor_missing_old_state \
+	tests/boss/test_channelcandidatepreinvestigator \
 	tests/boss/test_channelcreationdecider \
 	tests/boss/test_channelcreator_planner \
 	tests/boss/test_channelcreator_rearrangerbysize \

--- a/tests/boss/test_channelcandidatepreinvestigator.cpp
+++ b/tests/boss/test_channelcandidatepreinvestigator.cpp
@@ -1,0 +1,235 @@
+#undef NDEBUG
+#include"Boss/Mod/ChannelCandidatePreinvestigator.hpp"
+#include"Boss/Msg/PreinvestigateChannelCandidates.hpp"
+#include"Boss/Msg/ProposeChannelCandidates.hpp"
+#include"Boss/Msg/RequestConnect.hpp"
+#include"Boss/Msg/ResponseConnect.hpp"
+#include"Ev/Io.hpp"
+#include"Ev/start.hpp"
+#include"Ln/NodeId.hpp"
+#include"S/Bus.hpp"
+#include<assert.h>
+#include<functional>
+#include<string>
+#include<utility>
+#include<vector>
+
+namespace {
+
+/* A dummy Connector that DEFERS its responses.
+ *
+ * The real Connector performs the actual connection
+ * asynchronously, so several preinvestigation Cases can be
+ * parked in the module case-map before any ResponseConnect
+ * arrives.  A connector that answers synchronously (as in
+ * test_needsconnectsolicitor) lets every Case finish before
+ * the next one registers and cannot reproduce the same-node
+ * case collision (clboss#11 / study F-4).  */
+class DeferredConnector {
+private:
+	S::Bus& bus;
+	std::vector<std::string> pending;
+
+public:
+	size_t connects;
+
+	explicit
+	DeferredConnector(S::Bus& bus_) : bus(bus_), pending() {
+		connects = 0;
+		bus.subscribe<Boss::Msg::RequestConnect
+			     >([this](Boss::Msg::RequestConnect const& req) {
+			++connects;
+			pending.push_back(req.node);
+			return Ev::lift();
+		});
+	}
+	DeferredConnector(DeferredConnector&&) =delete;
+
+	/* Answer every pending connect, in arrival order.  New
+	 * requests raised while flushing (a surviving Case moving
+	 * on to its next candidate) stay pending for the next
+	 * flush.  */
+	Ev::Io<void> flush(bool success) {
+		return Ev::lift().then([this, success]() {
+			auto to_answer = std::move(pending);
+			pending.clear();
+			auto act = Ev::lift();
+			for (auto& node : to_answer) {
+				act += bus.raise(Boss::Msg::ResponseConnect{
+					std::move(node), success
+				});
+			}
+			return act;
+		});
+	}
+};
+
+class ProposalCollector {
+public:
+	std::vector<std::pair<std::string, std::string>> proposals;
+
+	explicit
+	ProposalCollector(S::Bus& bus) {
+		bus.subscribe<Boss::Msg::ProposeChannelCandidates
+			     >([this](Boss::Msg::ProposeChannelCandidates const& p) {
+			proposals.emplace_back( std::string(p.proposal)
+					      , std::string(p.patron)
+					      );
+			return Ev::lift();
+		});
+	}
+	ProposalCollector(ProposalCollector&&) =delete;
+
+	size_t
+	count(std::string const& node, std::string const& patron) {
+		auto n = size_t(0);
+		for (auto const& p : proposals) {
+			if (p.first == node && p.second == patron)
+				++n;
+		}
+		return n;
+	}
+};
+
+/* Valid 33-byte node ids (Ln::NodeId validates hex).  */
+auto const HUB = std::string("02")
+	+ "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	+ "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	;
+auto const OTHER = std::string("02")
+	+ "cccccccccccccccccccccccccccccccc"
+	+ "cccccccccccccccccccccccccccccccc"
+	;
+auto const OTHER2 = std::string("02")
+	+ "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	+ "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	;
+auto const PATRON1 = std::string("02")
+	+ "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+	+ "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+	;
+auto const PATRON2 = std::string("02")
+	+ "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+	+ "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+	;
+auto const PATRON3 = std::string("02")
+	+ "d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3"
+	+ "d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3"
+	;
+auto const PATRON4 = std::string("02")
+	+ "d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+	+ "d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+	;
+auto const PATRON5 = std::string("02")
+	+ "d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5"
+	+ "d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5"
+	;
+
+}
+
+int main() {
+	S::Bus bus;
+	DeferredConnector connector(bus);
+	ProposalCollector collector(bus);
+	Boss::Mod::ChannelCandidatePreinvestigator preinv(bus);
+
+	auto preinvestigate = [&bus]( std::vector<Boss::Msg::ProposeChannelCandidates> cs
+				   , std::size_t max_candidates
+				   ) {
+		return bus.raise(Boss::Msg::PreinvestigateChannelCandidates{
+			std::move(cs), max_candidates
+		});
+	};
+
+	auto test = Ev::lift().then([&]() {
+		/* Two finders concurrently preinvestigate batches
+		 * that share the same proposal node -- the E0 F-4
+		 * shape (several leaf patrons whose only peer is
+		 * the popular hub).  */
+		return preinvestigate(
+			{ Boss::Msg::ProposeChannelCandidates{
+				Ln::NodeId(HUB), Ln::NodeId(PATRON1)
+			} },
+			1
+		);
+	}).then([&]() {
+		return preinvestigate(
+			{ Boss::Msg::ProposeChannelCandidates{
+				Ln::NodeId(HUB), Ln::NodeId(PATRON2)
+			} },
+			1
+		);
+	}).then([&]() {
+		/* Both batches requested a connect...  */
+		assert(connector.connects == 2);
+		/* ...and neither has completed: no proposal can
+		 * surface before any ResponseConnect.  */
+		assert(collector.proposals.empty());
+
+		/* The real Connector answers asynchronously.  */
+		return connector.flush(true);
+	}).then([&]() {
+		/* clboss#11: both proposals must surface, each
+		 * attributed to its own patron.  Pre-fix,
+		 * add_case overwrote the first Case, destroying
+		 * it with its whole batch still unprocessed.  */
+		assert(collector.count(HUB, PATRON1) == 1);
+		assert(collector.count(HUB, PATRON2) == 1);
+		assert(collector.proposals.size() == 2);
+
+		/* Regression guard: a later, non-colliding batch
+		 * still surfaces normally.  */
+		return preinvestigate(
+			{ Boss::Msg::ProposeChannelCandidates{
+				Ln::NodeId(OTHER), Ln::NodeId(PATRON3)
+			} },
+			1
+		);
+	}).then([&]() {
+		assert(connector.connects == 3);
+		return connector.flush(true);
+	}).then([&]() {
+		assert(collector.count(OTHER, PATRON3) == 1);
+		assert(collector.proposals.size() == 3);
+
+		/* Collision on the failure path, with the
+		 * surviving Case owing more candidates: PATRON4
+		 * has a second candidate (OTHER2) that may only
+		 * be proposed if its Case survives the failed
+		 * connect to the shared node.  */
+		return preinvestigate(
+			{ Boss::Msg::ProposeChannelCandidates{
+				Ln::NodeId(HUB), Ln::NodeId(PATRON4)
+			}
+			, Boss::Msg::ProposeChannelCandidates{
+				Ln::NodeId(OTHER2), Ln::NodeId(PATRON4)
+			} },
+			2
+		);
+	}).then([&]() {
+		return preinvestigate(
+			{ Boss::Msg::ProposeChannelCandidates{
+				Ln::NodeId(HUB), Ln::NodeId(PATRON5)
+			} },
+			1
+		);
+	}).then([&]() {
+		assert(connector.connects == 5);
+		/* Both connects to the shared node fail.  */
+		return connector.flush(false);
+	}).then([&]() {
+		/* Nothing proposed from the failed connects.  */
+		assert(collector.proposals.size() == 3);
+		/* But PATRON4's Case lives on and now wants
+		 * OTHER2.  */
+		assert(connector.connects == 6);
+		return connector.flush(true);
+	}).then([&]() {
+		assert(collector.count(OTHER2, PATRON4) == 1);
+		assert(collector.proposals.size() == 4);
+
+		return Ev::lift(0);
+	});
+
+	return Ev::start(test);
+}


### PR DESCRIPTION
## Problem

`ChannelCandidatePreinvestigator` tracks in-flight preinvestigation
Cases in a `std::map<std::string, std::shared_ptr<Case>>` keyed by
node id.  When two finders concurrently preinvestigate batches that
contain the SAME proposal node — which the popularity finder makes
routine: it launches one `PreinvestigateChannelCandidates` per
selected patron via `Ev::map`, and several one-peered patrons of the
same popular hub all propose that hub — the second `add_case`
**overwrites** the first Case's entry.  The overwritten Case's last
`shared_ptr` then dies with its greenthread: that patron's entire
candidate batch is silently dropped, and the extra `ResponseConnect`
finds no case and is discarded.

Candidacy survives (one proposal per node is enough), but patron
attribution is lost and the dropped batch may contain further
candidates that never surface.

## Fix

Track concurrent same-node Cases in a
`std::map<std::string, std::queue<std::shared_ptr<Case>>>`: every
`ResponseConnect` pops the longest-waiting Case for that node; the
entry is erased before execution so a Case that re-registers the
same node from within its own continuation lands in a fresh entry.

## Tests

`tests/boss/test_channelcandidatepreinvestigator.cpp`: the dummy
Connector answers asynchronously (a synchronous dummy lets every
Case finish before the next registers and cannot reproduce the
race), two concurrent batches sharing a node must both surface with
their own patrons, and a surviving Case must continue to its NEXT
candidate after a failed connect to the shared node.  `make check`
green.

Live validation (regtest A/B, fresh unfunded nodes, popularity runs
300 ms apart, one-peered-patron draw): unpatched surfaces 1 of 3
proposers of the shared hub (two patrons silently dropped); patched
surfaces 3-of-3 on the hub and 2-of-2 on a second shared node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Queue concurrent `Case` objects per node in `ChannelCandidatePreinvestigator` instead of overwriting them.
- Add regression tests for same-node requests, patron attribution, deferred responses, and continuation after failed connections.
- Register the new test in `Makefile.am`; `make check` passes all 94 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->