### PR TITLE
ChannelCreateDestroyMonitor: a splice is not a channel loss

### DIFF
--- a/Boss/Mod/ChannelCreateDestroyMonitor.cpp
+++ b/Boss/Mod/ChannelCreateDestroyMonitor.cpp
@@ -94,7 +94,7 @@ void ChannelCreateDestroyMonitor::start() {
 				   , channeled.end()
 				   , curr_channeled.begin()
 				   , curr_channeled.end()
-				   , std::back_inserter(creations)
+				   , std::back_inserter(destructions)
 				   );
 
 		/* Combine.  */
@@ -194,13 +194,22 @@ void ChannelCreateDestroyMonitor::start() {
 					, err.what()
 					);
 		}
-		/* Only continue if we are leaving the CHANNELD_NORMAL
-		 * state, or leaving from CHANNELD_AWAITING_LOCKIN to
-		 * any state that is not CHANNELD_NORMAL.
+		/* A channel is live in CHANNELD_NORMAL and in
+		 * CHANNELD_AWAITING_SPLICE: a splice keeps the channel
+		 * open and forwarding until the new funding locks in,
+		 * and it returns to CHANNELD_NORMAL with a new short
+		 * channel id.  Only continue if we are leaving the live
+		 * states for some other state, or leaving
+		 * CHANNELD_AWAITING_LOCKIN for a state that is not live.
 		 */
-		if ( !( old_state == "CHANNELD_NORMAL"
+		auto live = [](std::string const& state) {
+			return state == "CHANNELD_NORMAL"
+			    || state == "CHANNELD_AWAITING_SPLICE"
+			     ;
+		};
+		if ( !( ( live(old_state) && !live(new_state) )
 		     || ( old_state == "CHANNELD_AWAITING_LOCKIN"
-		       && new_state != "CHANNELD_NORMAL"
+		       && !live(new_state)
 			)
 		      ))
 			return Ev::lift();

--- a/Boss/Msg/ChannelDestruction.hpp
+++ b/Boss/Msg/ChannelDestruction.hpp
@@ -9,9 +9,10 @@ namespace Boss { namespace Msg {
  *
  * @brief Tells everyone that we lost an existing channel
  * with a peer.
- * Basically, if we leave `CHANNELD_NORMAL`, or if we leave
- * `CHANNELD_AWAITING_LOCKIN` but did not enter
- * `CHANNELD_NORMAL`.
+ * Basically, if we leave the live states (`CHANNELD_NORMAL`, or
+ * `CHANNELD_AWAITING_SPLICE` while a splice locks in) for some
+ * other state, or if we leave `CHANNELD_AWAITING_LOCKIN` but did
+ * not enter a live state.
  * See also `Boss::Msg::ChannelCreation`.
  */
 struct ChannelDestruction {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   CLN's `channel_state_changed` notification as soon as it carries a
   short channel id, and a part with one end still unknown is
   attributed to the end that is known (#337).
+- A splice no longer reads as losing the channel.  CLN keeps a
+  spliced channel open and forwarding in `CHANNELD_AWAITING_SPLICE`
+  until the new funding locks in, which the create/destroy monitor
+  took as leaving `CHANNELD_NORMAL`: it announced a
+  `ChannelDestruction`, and a `ChannelCreation` minutes later, so
+  the peer's complaint history was archived, its channel age reset,
+  and the fee monitor's state for it flushed.  That state now counts
+  as live.  The monitor's polling path also never reported a
+  destruction: peers that had gone were appended to the creations
+  list.
+
 
 ## [0.16.3] - 2026-08-18: "Tougher Than the Race"
 


### PR DESCRIPTION
A channel in CHANNELD_AWAITING_SPLICE is open and forwarding; the
monitor took the transition out of CHANNELD_NORMAL as a destruction
and the listpeers poll re-added the peer minutes later, which
archived its complaints, reset its age and flushed the fee monitor's
state.  Seen on a mainnet splice-out on 2026-09-01: ChannelDestruction
13 ms after signing, ChannelCreation 5 minutes later, a feemon row
with NULL balances after lock-in.  The live states are now
CHANNELD_NORMAL and CHANNELD_AWAITING_SPLICE.

Also fixes the poll path writing destroyed peers into the creations
list, so polling never reported a destruction and reported a vanished
peer as created.

Compiles clean under the tree's -Wall -Werror.  Draft until validated.

Validation pending

- [ ] Splice on the signet pair (as in the June experiment) with this
      build: the log shows no ChannelDestruction / ChannelCreation for
      the peer across AWAITING_SPLICE and lock-in; the peer stays in the
      managed set; PeerComplaintsDesk keeps its live complaints;
      PeerJudge age does not reset; the first feemon row after lock-in
      carries balances.
- [ ] A cooperative close still logs ChannelDestruction (notification
      path unchanged for a real close).
- [ ] Poll path: a peer whose channel disappears between two polls is
      now reported as a destruction, not a creation (unit test or a
      forced scenario on signet).
